### PR TITLE
Add smoldot-based WebRTC dialer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ litep2p/target
 libp2p/target
 utils/target
 /target
+server.log
+*/server.log
+.idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,12 +263,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "attohttpc"
-version = "0.24.1"
+name = "atomic-waker"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9a9bf8b79a749ee0b911b91b671cc2b6c670bdbc7e3dfd537576ddc94bb2a2"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "attohttpc"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
 dependencies = [
- "http 0.2.12",
+ "base64",
+ "http",
  "log",
  "url",
 ]
@@ -295,6 +308,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,6 +324,15 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -348,6 +376,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,12 +412,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "shlex",
+]
+
+[[package]]
+name = "ccm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae3c82e4355234767756212c570e29833699ab63e6ffd161887314cc5b43847"
+dependencies = [
+ "aead",
+ "cipher",
+ "ctr",
+ "subtle",
 ]
 
 [[package]]
@@ -615,6 +673,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,6 +764,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -741,6 +812,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -767,6 +839,20 @@ name = "dtoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
 
 [[package]]
 name = "ed25519"
@@ -798,6 +884,27 @@ name = "either"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "enum-as-inner"
@@ -853,6 +960,16 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "fiat-crypto"
@@ -1066,6 +1183,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1110,17 +1228,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
-name = "h2"
-version = "0.3.26"
+name = "group"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+dependencies = [
+ "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "futures-util",
- "http 0.2.12",
+ "http",
  "indexmap",
  "slab",
  "tokio",
@@ -1165,31 +1294,6 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hickory-proto"
-version = "0.24.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92652067c9ce6f66ce53cc38d1169daa36e6e7eb7dd3b63b5103bd9d97117248"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna",
- "ipnet",
- "once_cell",
- "rand 0.8.5",
- "socket2",
- "thiserror 1.0.69",
- "tinyvec",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "hickory-proto"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
@@ -1204,34 +1308,14 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.0",
- "ring 0.17.11",
+ "rand 0.9.2",
+ "ring",
+ "socket2",
  "thiserror 2.0.12",
  "tinyvec",
  "tokio",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "hickory-resolver"
-version = "0.24.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbb117a1ca520e111743ab2f6688eddee69db4e0ea242545a604dce8a66fd22e"
-dependencies = [
- "cfg-if",
- "futures-util",
- "hickory-proto 0.24.4",
- "ipconfig",
- "lru-cache",
- "once_cell",
- "parking_lot",
- "rand 0.8.5",
- "resolv-conf",
- "smallvec",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -1242,12 +1326,12 @@ checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
 dependencies = [
  "cfg-if",
  "futures-util",
- "hickory-proto 0.25.2",
+ "hickory-proto",
  "ipconfig",
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.0",
+ "rand 0.9.2",
  "resolv-conf",
  "smallvec",
  "thiserror 2.0.12",
@@ -1286,17 +1370,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
@@ -1308,12 +1381,24 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 0.2.12",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -1324,33 +1409,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
 
 [[package]]
-name = "httpdate"
-version = "1.0.3"
+name = "hyper"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
 
 [[package]]
-name = "hyper"
-version = "0.14.32"
+name = "hyper-util"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http 0.2.12",
+ "http",
  "http-body",
- "httparse",
- "httpdate",
- "itoa",
+ "hyper",
+ "libc",
  "pin-project-lite",
  "socket2",
  "tokio",
  "tower-service",
  "tracing",
- "want",
 ]
 
 [[package]]
@@ -1527,18 +1623,20 @@ dependencies = [
 
 [[package]]
 name = "igd-next"
-version = "0.14.3"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "064d90fec10d541084e7b39ead8875a5a80d9114a2b18791565253bae25f49e4"
+checksum = "516893339c97f6011282d5825ac94fc1c7aad5cad26bdc2d0cee068c0bf97f97"
 dependencies = [
  "async-trait",
  "attohttpc",
  "bytes",
  "futures",
- "http 0.2.12",
+ "http",
+ "http-body-util",
  "hyper",
+ "hyper-util",
  "log",
- "rand 0.8.5",
+ "rand 0.9.2",
  "tokio",
  "url",
  "xmltree",
@@ -1560,7 +1658,28 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
+ "block-padding",
  "generic-array",
+]
+
+[[package]]
+name = "interceptor"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ab04c530fd82e414e40394cabe5f0ebfe30d119f10fe29d6e3561926af412e"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "log",
+ "portable-atomic",
+ "rand 0.8.5",
+ "rtcp",
+ "rtp",
+ "thiserror 1.0.69",
+ "tokio",
+ "waitgroup",
+ "webrtc-srtp",
+ "webrtc-util",
 ]
 
 [[package]]
@@ -1637,9 +1756,9 @@ checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libp2p"
-version = "0.54.1"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbe80f9c7e00526cd6b838075b9c171919404a4732cb2fa8ece0a093223bfc4"
+checksum = "ce71348bf5838e46449ae240631117b487073d5f347c06d434caddcb91dceb5a"
 dependencies = [
  "bytes",
  "either",
@@ -1667,38 +1786,36 @@ dependencies = [
  "multiaddr 0.18.2",
  "pin-project",
  "rw-stream-sink",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "libp2p-allow-block-list"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1027ccf8d70320ed77e984f273bc8ce952f623762cb9bf2d126df73caef8041"
+checksum = "d16ccf824ee859ca83df301e1c0205270206223fd4b1f2e512a693e1912a8f4a"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "void",
 ]
 
 [[package]]
 name = "libp2p-connection-limits"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d003540ee8baef0d254f7b6bfd79bac3ddf774662ca0abf69186d517ef82ad8"
+checksum = "a18b8b607cf3bfa2f8c57db9c7d8569a315d5cc0a282e6bfd5ebfc0a9840b2a0"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "void",
 ]
 
 [[package]]
 name = "libp2p-core"
-version = "0.42.0"
+version = "0.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a61f26c83ed111104cd820fe9bc3aaabbac5f1652a1d213ed6e900b7918a1298"
+checksum = "4d28e2d2def7c344170f5c6450c0dbe3dfef655610dbfde2f6ac28a527abbe36"
 dependencies = [
  "either",
  "fnv",
@@ -1708,29 +1825,26 @@ dependencies = [
  "multiaddr 0.18.2",
  "multihash 0.19.3",
  "multistream-select",
- "once_cell",
  "parking_lot",
  "pin-project",
  "quick-protobuf",
  "rand 0.8.5",
  "rw-stream-sink",
- "smallvec",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tracing",
  "unsigned-varint 0.8.0",
- "void",
  "web-time",
 ]
 
 [[package]]
 name = "libp2p-dns"
-version = "0.42.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97f37f30d5c7275db282ecd86e54f29dd2176bd3ac656f06abf43bedb21eb8bd"
+checksum = "0b770c1c8476736ca98c578cba4b505104ff8e842c2876b528925f9766379f9a"
 dependencies = [
  "async-trait",
  "futures",
- "hickory-resolver 0.24.4",
+ "hickory-resolver",
  "libp2p-core",
  "libp2p-identity",
  "parking_lot",
@@ -1740,9 +1854,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identify"
-version = "0.45.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1711b004a273be4f30202778856368683bd9a83c4c7dcc8f848847606831a4e3"
+checksum = "8ab792a8b68fdef443a62155b01970c81c3aadab5e659621b063ef252a8e65e8"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -1752,20 +1866,18 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "lru",
  "quick-protobuf",
  "quick-protobuf-codec",
  "smallvec",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tracing",
- "void",
 ]
 
 [[package]]
 name = "libp2p-identity"
-version = "0.2.10"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "257b5621d159b32282eac446bed6670c39c7dc68a200a992d8f056afa0066f6d"
+checksum = "3104e13b51e4711ff5738caa1fb54467c8604c2e94d607e27745bcf709068774"
 dependencies = [
  "bs58",
  "ed25519-dalek",
@@ -1774,18 +1886,17 @@ dependencies = [
  "quick-protobuf",
  "rand 0.8.5",
  "sha2",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tracing",
  "zeroize",
 ]
 
 [[package]]
 name = "libp2p-kad"
-version = "0.46.2"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced237d0bd84bbebb7c2cad4c073160dacb4fe40534963c32ed6d4c6bb7702a3"
+checksum = "13d3fd632a5872ec804d37e7413ceea20588f69d027a0fa3c46f82574f4dee60"
 dependencies = [
- "arrayvec",
  "asynchronous-codec",
  "bytes",
  "either",
@@ -1801,22 +1912,20 @@ dependencies = [
  "rand 0.8.5",
  "sha2",
  "smallvec",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tracing",
- "uint 0.9.5",
- "void",
+ "uint",
  "web-time",
 ]
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.46.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b8546b6644032565eb29046b42744aee1e9f261ed99671b2c93fb140dba417"
+checksum = "c66872d0f1ffcded2788683f76931be1c52e27f343edb93bc6d0bcd8887be443"
 dependencies = [
- "data-encoding",
  "futures",
- "hickory-proto 0.24.4",
+ "hickory-proto",
  "if-watch",
  "libp2p-core",
  "libp2p-identity",
@@ -1826,14 +1935,13 @@ dependencies = [
  "socket2",
  "tokio",
  "tracing",
- "void",
 ]
 
 [[package]]
 name = "libp2p-metrics"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ebafa94a717c8442d8db8d3ae5d1c6a15e30f2d347e0cd31d057ca72e42566"
+checksum = "805a555148522cb3414493a5153451910cb1a146c53ffbf4385708349baf62b7"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -1849,25 +1957,22 @@ dependencies = [
 
 [[package]]
 name = "libp2p-noise"
-version = "0.45.0"
+version = "0.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36b137cb1ae86ee39f8e5d6245a296518912014eaa87427d24e6ff58cfc1b28c"
+checksum = "bc73eacbe6462a0eb92a6527cac6e63f02026e5407f8831bde8293f19217bfbf"
 dependencies = [
  "asynchronous-codec",
  "bytes",
- "curve25519-dalek",
  "futures",
  "libp2p-core",
  "libp2p-identity",
  "multiaddr 0.18.2",
  "multihash 0.19.3",
- "once_cell",
  "quick-protobuf",
  "rand 0.8.5",
- "sha2",
  "snow",
  "static_assertions",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tracing",
  "x25519-dalek",
  "zeroize",
@@ -1887,7 +1992,9 @@ dependencies = [
  "libp2p-noise",
  "libp2p-swarm",
  "libp2p-tls",
+ "libp2p-webrtc",
  "libp2p-yamux",
+ "rand 0.8.5",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -1898,11 +2005,10 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.45.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "005a34420359223b974ee344457095f027e51346e992d1e0dcd35173f4cdd422"
+checksum = "74bb7fcdfd9fead4144a3859da0b49576f171a8c8c7c0bfc7c541921d25e60d3"
 dependencies = [
- "either",
  "futures",
  "futures-timer",
  "libp2p-core",
@@ -1910,59 +2016,53 @@ dependencies = [
  "libp2p-swarm",
  "rand 0.8.5",
  "tracing",
- "void",
  "web-time",
 ]
 
 [[package]]
 name = "libp2p-quic"
-version = "0.11.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46352ac5cd040c70e88e7ff8257a2ae2f891a4076abad2c439584a31c15fd24e"
+checksum = "8dc448b2de9f4745784e3751fe8bc6c473d01b8317edd5ababcb0dec803d843f"
 dependencies = [
- "bytes",
  "futures",
  "futures-timer",
  "if-watch",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-tls",
- "parking_lot",
  "quinn",
  "rand 0.8.5",
- "ring 0.17.11",
+ "ring",
  "rustls",
  "socket2",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.27.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1356c9e376a94a75ae830c42cdaea3d4fe1290ba409a22c809033d1b7dcab0a6"
+checksum = "a9f1cca83488b90102abac7b67d5c36fc65bc02ed47620228af7ed002e6a1478"
 dependencies = [
  "async-trait",
  "futures",
  "futures-bounded",
- "futures-timer",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
  "rand 0.8.5",
  "smallvec",
  "tracing",
- "void",
- "web-time",
 ]
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.45.1"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7dd6741793d2c1fb2088f67f82cf07261f25272ebe3c0b0c311e0c6b50e851a"
+checksum = "6aa762e5215919a34e31c35d4b18bf2e18566ecab7f8a3d39535f4a3068f8b62"
 dependencies = [
  "either",
  "fnv",
@@ -1973,39 +2073,35 @@ dependencies = [
  "libp2p-swarm-derive",
  "lru",
  "multistream-select",
- "once_cell",
  "rand 0.8.5",
  "smallvec",
  "tokio",
  "tracing",
- "void",
  "web-time",
 ]
 
 [[package]]
 name = "libp2p-swarm-derive"
-version = "0.35.0"
+version = "0.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206e0aa0ebe004d778d79fb0966aa0de996c19894e2c0605ba2f8524dd4443d8"
+checksum = "dd297cf53f0cb3dee4d2620bb319ae47ef27c702684309f682bdb7e55a18ae9c"
 dependencies = [
  "heck",
- "proc-macro2",
  "quote",
  "syn 2.0.99",
 ]
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.42.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad964f312c59dcfcac840acd8c555de8403e295d39edf96f5240048b5fcaa314"
+checksum = "65b4e030c52c46c8d01559b2b8ca9b7c4185f10576016853129ca1fe5cd1a644"
 dependencies = [
  "futures",
  "futures-timer",
  "if-watch",
  "libc",
  "libp2p-core",
- "libp2p-identity",
  "socket2",
  "tokio",
  "tracing",
@@ -2013,28 +2109,28 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tls"
-version = "0.5.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b23dddc2b9c355f73c1e36eb0c3ae86f7dc964a3715f0731cfad352db4d847"
+checksum = "96ff65a82e35375cbc31ebb99cacbbf28cb6c4fefe26bf13756ddcf708d40080"
 dependencies = [
  "futures",
  "futures-rustls",
  "libp2p-core",
  "libp2p-identity",
  "rcgen",
- "ring 0.17.11",
+ "ring",
  "rustls",
- "rustls-webpki 0.101.7",
- "thiserror 1.0.69",
- "x509-parser 0.16.0",
+ "rustls-webpki 0.103.3",
+ "thiserror 2.0.12",
+ "x509-parser 0.17.0",
  "yasna",
 ]
 
 [[package]]
 name = "libp2p-upnp"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01bf2d1b772bd3abca049214a3304615e6a36fa6ffc742bdd1ba774486200b8f"
+checksum = "4757e65fe69399c1a243bbb90ec1ae5a2114b907467bf09f3575e899815bb8d3"
 dependencies = [
  "futures",
  "futures-timer",
@@ -2043,14 +2139,61 @@ dependencies = [
  "libp2p-swarm",
  "tokio",
  "tracing",
- "void",
+]
+
+[[package]]
+name = "libp2p-webrtc"
+version = "0.9.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57bc51d86236d33762bccf5015e4ece458c549476c362040d4e1e6f3615e41b0"
+dependencies = [
+ "async-trait",
+ "futures",
+ "futures-timer",
+ "hex",
+ "if-watch",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-noise",
+ "libp2p-webrtc-utils",
+ "multihash 0.19.3",
+ "rand 0.8.5",
+ "rcgen",
+ "stun",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "webrtc",
+]
+
+[[package]]
+name = "libp2p-webrtc-utils"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490abff5ee5f9a7a77f0145c79cc97c76941231a3626f4dee18ebf2abb95618f"
+dependencies = [
+ "asynchronous-codec",
+ "bytes",
+ "futures",
+ "hex",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-noise",
+ "quick-protobuf",
+ "quick-protobuf-codec",
+ "rand 0.8.5",
+ "serde",
+ "sha2",
+ "tinytemplate",
+ "tracing",
 ]
 
 [[package]]
 name = "libp2p-websocket"
-version = "0.44.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "888b2ff2e5d8dcef97283daab35ad1043d18952b65e05279eecbe02af4c6e347"
+checksum = "520e29066a48674c007bc11defe5dce49908c24cafd8fad2f5e1a6a8726ced53"
 dependencies = [
  "either",
  "futures",
@@ -2061,32 +2204,26 @@ dependencies = [
  "pin-project-lite",
  "rw-stream-sink",
  "soketto",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tracing",
  "url",
- "webpki-roots",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "788b61c80789dba9760d8c669a5bedb642c8267555c803fabd8396e4ca5c5882"
+checksum = "f15df094914eb4af272acf9adaa9e287baa269943f32ea348ba29cfb9bfc60d8"
 dependencies = [
  "either",
  "futures",
  "libp2p-core",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tracing",
  "yamux 0.12.1",
  "yamux 0.13.5",
 ]
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2113,7 +2250,7 @@ dependencies = [
  "ed25519-dalek",
  "futures",
  "futures-timer",
- "hickory-resolver 0.25.2",
+ "hickory-resolver",
  "indexmap",
  "libc",
  "mockall",
@@ -2138,7 +2275,7 @@ dependencies = [
  "tokio-tungstenite",
  "tokio-util",
  "tracing",
- "uint 0.10.0",
+ "uint",
  "unsigned-varint 0.8.0",
  "url",
  "x25519-dalek",
@@ -2201,15 +2338,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lru-cache"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
-dependencies = [
- "linked-hash-map",
-]
-
-[[package]]
 name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2225,10 +2353,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -2493,6 +2640,8 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
+ "memoffset",
+ "pin-utils",
 ]
 
 [[package]]
@@ -2669,6 +2818,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2711,6 +2884,15 @@ checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
 dependencies = [
  "base64",
  "serde",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -2833,7 +3015,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2870,6 +3052,15 @@ checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
 dependencies = [
  "proc-macro2",
  "syn 2.0.99",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -2917,9 +3108,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.22.3"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504ee9ff529add891127c4827eb481bd69dc0ebc72e9a682e187db4caa60c3ca"
+checksum = "cf41c1a7c32ed72abe5082fb19505b969095c12da9f5732a4bc9878757fd087c"
 dependencies = [
  "dtoa",
  "itoa",
@@ -3046,7 +3237,7 @@ dependencies = [
  "bytes",
  "getrandom 0.2.15",
  "rand 0.8.5",
- "ring 0.17.11",
+ "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
@@ -3093,13 +3284,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.21",
 ]
 
 [[package]]
@@ -3142,13 +3332,15 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.11.3"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c4f3084aa3bc7dfbba4eff4fab2a54db4324965d8872ab933565e6fbd83bc6"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
 dependencies = [
  "pem",
- "ring 0.16.20",
+ "ring",
+ "rustls-pki-types",
  "time",
+ "x509-parser 0.16.0",
  "yasna",
 ]
 
@@ -3216,32 +3408,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "ring"
-version = "0.16.20"
+name = "rfc6979"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
+ "hmac",
+ "subtle",
 ]
 
 [[package]]
 name = "ring"
-version = "0.17.11"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5349ae27d3887ca812fb375b45a4fbb36d8d12d2df394968cd86e35683fe73"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom 0.2.15",
  "libc",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rtcp"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8306430fb118b7834bbee50e744dc34826eca1da2158657a3d6cbc70e24c2096"
+dependencies = [
+ "bytes",
+ "thiserror 1.0.69",
+ "webrtc-util",
 ]
 
 [[package]]
@@ -3260,6 +3458,21 @@ dependencies = [
  "nix",
  "thiserror 1.0.69",
  "tokio",
+]
+
+[[package]]
+name = "rtp"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e68baca5b6cb4980678713f0d06ef3a432aa642baefcbfd0f4dd2ef9eb5ab550"
+dependencies = [
+ "bytes",
+ "memchr",
+ "portable-atomic",
+ "rand 0.8.5",
+ "serde",
+ "thiserror 1.0.69",
+ "webrtc-util",
 ]
 
 [[package]]
@@ -3312,7 +3525,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
 dependencies = [
  "once_cell",
- "ring 0.17.11",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki 0.102.8",
  "subtle",
@@ -3342,23 +3555,24 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring 0.17.11",
- "untrusted 0.9.0",
-]
-
-[[package]]
-name = "rustls-webpki"
 version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
- "ring 0.17.11",
+ "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -3377,6 +3591,12 @@ dependencies = [
  "pin-project",
  "static_assertions",
 ]
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "schannel"
@@ -3412,6 +3632,32 @@ dependencies = [
  "rand 0.8.5",
  "slab",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "sdp"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02a526161f474ae94b966ba622379d939a8fe46c930eebbadb73e339622599d5"
+dependencies = [
+ "rand 0.8.5",
+ "substring",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3464,6 +3710,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.142"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3511,11 +3769,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
+ "digest",
  "rand_core 0.6.4",
 ]
 
@@ -3544,6 +3812,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smol_str"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "snow"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3554,7 +3831,7 @@ dependencies = [
  "chacha20poly1305",
  "curve25519-dalek",
  "rand_core 0.6.4",
- "ring 0.17.11",
+ "ring",
  "rustc_version",
  "sha2",
  "subtle",
@@ -3584,12 +3861,6 @@ dependencies = [
  "rand 0.8.5",
  "sha1",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spki"
@@ -3639,6 +3910,34 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "stun"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea256fb46a13f9204e9dee9982997b2c3097db175a9fddaa8350310d03c4d5a3"
+dependencies = [
+ "base64",
+ "crc",
+ "lazy_static",
+ "md-5",
+ "rand 0.8.5",
+ "ring",
+ "subtle",
+ "thiserror 1.0.69",
+ "tokio",
+ "url",
+ "webrtc-util",
+]
+
+[[package]]
+name = "substring"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ee6433ecef213b2e72f587ef64a2f5943e7cd16fbd82dbe8bc07486c534c86"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "subtle"
@@ -3830,6 +4129,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3857,6 +4166,7 @@ dependencies = [
  "mio",
  "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "slab",
  "socket2",
  "tokio-macros",
@@ -4016,10 +4326,10 @@ checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.2.0",
+ "http",
  "httparse",
  "log",
- "rand 0.9.0",
+ "rand 0.9.2",
  "rustls",
  "rustls-pki-types",
  "sha1",
@@ -4029,22 +4339,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "turn"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0044fdae001dd8a1e247ea6289abf12f4fcea1331a2364da512f9cd680bbd8cb"
+dependencies = [
+ "async-trait",
+ "base64",
+ "futures",
+ "log",
+ "md-5",
+ "portable-atomic",
+ "rand 0.8.5",
+ "ring",
+ "stun",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "webrtc-util",
+]
+
+[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
-
-[[package]]
-name = "uint"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
-dependencies = [
- "byteorder",
- "crunchy",
- "hex",
- "static_assertions",
-]
 
 [[package]]
 name = "uint"
@@ -4095,12 +4414,6 @@ dependencies = [
  "bytes",
  "tokio-util",
 ]
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -4186,6 +4499,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
+name = "waitgroup"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1f50000a783467e6c0200f9d10642f4bc424e39efc1b770203e88b488f79292"
+dependencies = [
+ "atomic-waker",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4268,16 +4590,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.77"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4289,9 +4601,230 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.4"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.2",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webrtc"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30367074d9f18231d28a74fab0120856b2b665da108d71a12beab7185a36f97b"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "hex",
+ "interceptor",
+ "lazy_static",
+ "log",
+ "portable-atomic",
+ "rand 0.8.5",
+ "rcgen",
+ "regex",
+ "ring",
+ "rtcp",
+ "rtp",
+ "rustls",
+ "sdp",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smol_str",
+ "stun",
+ "thiserror 1.0.69",
+ "time",
+ "tokio",
+ "turn",
+ "url",
+ "waitgroup",
+ "webrtc-data",
+ "webrtc-dtls",
+ "webrtc-ice",
+ "webrtc-mdns",
+ "webrtc-media",
+ "webrtc-sctp",
+ "webrtc-srtp",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-data"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec93b991efcd01b73c5b3503fa8adba159d069abe5785c988ebe14fcf8f05d1"
+dependencies = [
+ "bytes",
+ "log",
+ "portable-atomic",
+ "thiserror 1.0.69",
+ "tokio",
+ "webrtc-sctp",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-dtls"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c9b89fc909f9da0499283b1112cd98f72fec28e55a54a9e352525ca65cd95c"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "async-trait",
+ "bincode",
+ "byteorder",
+ "cbc",
+ "ccm",
+ "der-parser 9.0.0",
+ "hkdf",
+ "hmac",
+ "log",
+ "p256",
+ "p384",
+ "portable-atomic",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "rcgen",
+ "ring",
+ "rustls",
+ "sec1",
+ "serde",
+ "sha1",
+ "sha2",
+ "subtle",
+ "thiserror 1.0.69",
+ "tokio",
+ "webrtc-util",
+ "x25519-dalek",
+ "x509-parser 0.16.0",
+]
+
+[[package]]
+name = "webrtc-ice"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348b28b593f7709ac98d872beb58c0009523df652c78e01b950ab9c537ff17d"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "crc",
+ "log",
+ "portable-atomic",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "stun",
+ "thiserror 1.0.69",
+ "tokio",
+ "turn",
+ "url",
+ "uuid",
+ "waitgroup",
+ "webrtc-mdns",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-mdns"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6dfe9686c6c9c51428da4de415cb6ca2dc0591ce2b63212e23fd9cccf0e316b"
+dependencies = [
+ "log",
+ "socket2",
+ "thiserror 1.0.69",
+ "tokio",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-media"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e153be16b8650021ad3e9e49ab6e5fa9fb7f6d1c23c213fd8bbd1a1135a4c704"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "rand 0.8.5",
+ "rtp",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "webrtc-sctp"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5faf3846ec4b7e64b56338d62cbafe084aa79806b0379dff5cc74a8b7a2b3063"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "crc",
+ "log",
+ "portable-atomic",
+ "rand 0.8.5",
+ "thiserror 1.0.69",
+ "tokio",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-srtp"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "771db9993712a8fb3886d5be4613ebf27250ef422bd4071988bf55f1ed1a64fa"
+dependencies = [
+ "aead",
+ "aes",
+ "aes-gcm",
+ "byteorder",
+ "bytes",
+ "ctr",
+ "hmac",
+ "log",
+ "rtcp",
+ "rtp",
+ "sha1",
+ "subtle",
+ "thiserror 1.0.69",
+ "tokio",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-util"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1438a8fd0d69c5775afb4a71470af92242dbd04059c61895163aa3c1ef933375"
+dependencies = [
+ "async-trait",
+ "bitflags 1.3.2",
+ "bytes",
+ "ipnet",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix",
+ "portable-atomic",
+ "rand 0.8.5",
+ "thiserror 1.0.69",
+ "tokio",
+ "winapi",
+]
 
 [[package]]
 name = "widestring"
@@ -4664,6 +5197,7 @@ dependencies = [
  "lazy_static",
  "nom",
  "oid-registry 0.7.1",
+ "ring",
  "rusticata-macros",
  "thiserror 1.0.69",
  "time",
@@ -4727,7 +5261,7 @@ dependencies = [
  "nohash-hasher",
  "parking_lot",
  "pin-project",
- "rand 0.9.0",
+ "rand 0.9.2",
  "static_assertions",
  "web-time",
 ]
@@ -4772,16 +5306,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf01143b2dd5d134f11f545cf9f1431b13b749695cb33bcce051e7568f99478"
-dependencies = [
- "zerocopy-derive 0.8.21",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -4789,17 +5314,6 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.99",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712c8386f4f4299382c9abee219bee7084f78fb939d88b6840fcc1320d5f6da2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1651,8 +1651,7 @@ dependencies = [
 [[package]]
 name = "interceptor"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac0781c825d602095113772e389ef0607afcb869ae0e68a590d8e0799cdcef8"
+source = "git+https://github.com/haikoschol/webrtc.git?branch=always-send-ice-keepalives#d7a8da915be8517f4f49f9a2db7541e1f9d11703"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3421,8 +3420,7 @@ dependencies = [
 [[package]]
 name = "rtcp"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9689528bf3a9eb311fd938d05516dd546412f9ce4fffc8acfc1db27cc3dbf72"
+source = "git+https://github.com/haikoschol/webrtc.git?branch=always-send-ice-keepalives#d7a8da915be8517f4f49f9a2db7541e1f9d11703"
 dependencies = [
  "bytes",
  "thiserror 1.0.69",
@@ -3450,8 +3448,7 @@ dependencies = [
 [[package]]
 name = "rtp"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54733451a67d76caf9caa07a7a2cec6871ea9dda92a7847f98063d459200f4b"
+source = "git+https://github.com/haikoschol/webrtc.git?branch=always-send-ice-keepalives#d7a8da915be8517f4f49f9a2db7541e1f9d11703"
 dependencies = [
  "bytes",
  "memchr",
@@ -3625,8 +3622,7 @@ dependencies = [
 [[package]]
 name = "sdp"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd277015eada44a0bb810a4b84d3bf6e810573fa62fb442f457edf6a1087a69"
+source = "git+https://github.com/haikoschol/webrtc.git?branch=always-send-ice-keepalives#d7a8da915be8517f4f49f9a2db7541e1f9d11703"
 dependencies = [
  "rand 0.8.5",
  "substring",
@@ -3941,8 +3937,7 @@ dependencies = [
 [[package]]
 name = "stun"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dbc2bab375524093c143dc362a03fb6a1fb79e938391cdb21665688f88a088a"
+source = "git+https://github.com/haikoschol/webrtc.git?branch=always-send-ice-keepalives#d7a8da915be8517f4f49f9a2db7541e1f9d11703"
 dependencies = [
  "base64",
  "crc",
@@ -4368,8 +4363,7 @@ dependencies = [
 [[package]]
 name = "turn"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f5aea1116456e1da71c45586b87c72e3b43164fbf435eb93ff6aa475416a9a4"
+source = "git+https://github.com/haikoschol/webrtc.git?branch=always-send-ice-keepalives#d7a8da915be8517f4f49f9a2db7541e1f9d11703"
 dependencies = [
  "async-trait",
  "base64",
@@ -4653,8 +4647,7 @@ dependencies = [
 [[package]]
 name = "webrtc"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24bab7195998d605c862772f90a452ba655b90a2f463c850ac032038890e367a"
+source = "git+https://github.com/haikoschol/webrtc.git?branch=always-send-ice-keepalives#d7a8da915be8517f4f49f9a2db7541e1f9d11703"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4697,8 +4690,7 @@ dependencies = [
 [[package]]
 name = "webrtc-data"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e97b932854da633a767eff0cc805425a2222fc6481e96f463e57b015d949d1d"
+source = "git+https://github.com/haikoschol/webrtc.git?branch=always-send-ice-keepalives#d7a8da915be8517f4f49f9a2db7541e1f9d11703"
 dependencies = [
  "bytes",
  "log",
@@ -4712,8 +4704,7 @@ dependencies = [
 [[package]]
 name = "webrtc-dtls"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ccbe4d9049390ab52695c3646c1395c877e16c15fb05d3bda8eee0c7351711c"
+source = "git+https://github.com/haikoschol/webrtc.git?branch=always-send-ice-keepalives#d7a8da915be8517f4f49f9a2db7541e1f9d11703"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -4749,8 +4740,7 @@ dependencies = [
 [[package]]
 name = "webrtc-ice"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb51bde0d790f109a15bfe4d04f1b56fb51d567da231643cb3f21bb74d678997"
+source = "git+https://github.com/haikoschol/webrtc.git?branch=always-send-ice-keepalives#d7a8da915be8517f4f49f9a2db7541e1f9d11703"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4774,8 +4764,7 @@ dependencies = [
 [[package]]
 name = "webrtc-mdns"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "979cc85259c53b7b620803509d10d35e2546fa505d228850cbe3f08765ea6ea8"
+source = "git+https://github.com/haikoschol/webrtc.git?branch=always-send-ice-keepalives#d7a8da915be8517f4f49f9a2db7541e1f9d11703"
 dependencies = [
  "log",
  "socket2 0.5.10",
@@ -4787,8 +4776,7 @@ dependencies = [
 [[package]]
 name = "webrtc-media"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80041211deccda758a3e19aa93d6b10bc1d37c9183b519054b40a83691d13810"
+source = "git+https://github.com/haikoschol/webrtc.git?branch=always-send-ice-keepalives#d7a8da915be8517f4f49f9a2db7541e1f9d11703"
 dependencies = [
  "byteorder",
  "bytes",
@@ -4800,8 +4788,7 @@ dependencies = [
 [[package]]
 name = "webrtc-sctp"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07439c134425d51d2f10907aaf2f815fdfb587dce19fe94a4ae8b5faf2aae5ae"
+source = "git+https://github.com/haikoschol/webrtc.git?branch=always-send-ice-keepalives#d7a8da915be8517f4f49f9a2db7541e1f9d11703"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4818,8 +4805,7 @@ dependencies = [
 [[package]]
 name = "webrtc-srtp"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01e773f79b09b057ffbda6b03fe7b43403b012a240cf8d05d630674c3723b5bb"
+source = "git+https://github.com/haikoschol/webrtc.git?branch=always-send-ice-keepalives#d7a8da915be8517f4f49f9a2db7541e1f9d11703"
 dependencies = [
  "aead",
  "aes",
@@ -4862,8 +4848,7 @@ dependencies = [
 [[package]]
 name = "webrtc-util"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64bfb10dbe6d762f80169ae07cf252bafa1f764b9594d140008a0231c0cdce58"
+source = "git+https://github.com/haikoschol/webrtc.git?branch=always-send-ice-keepalives#d7a8da915be8517f4f49f9a2db7541e1f9d11703"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,6 +343,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "auto_generate_cdp"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "359220d0b9360b79d17d648d0a3ba1e792ec36bdbc227c8fd0351df3a0415704"
+dependencies = [
+ "convert_case 0.8.0",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "ureq",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -747,6 +761,15 @@ dependencies = [
 
 [[package]]
 name = "convert_case"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
@@ -937,6 +960,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.99",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.99",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1018,6 +1076,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1208,6 +1297,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1282,6 +1377,16 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flate2"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1587,6 +1692,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown",
+]
+
+[[package]]
+name = "headless_chrome"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "082c435ae636f62394526fe9c4c6b796efc1cec950c664456a44e5233ac5e2b8"
+dependencies = [
+ "anyhow",
+ "auto_generate_cdp",
+ "base64 0.22.1",
+ "derive_builder",
+ "log",
+ "rand 0.9.2",
+ "regex",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.17",
+ "tungstenite 0.28.0",
+ "url",
+ "which",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -1945,6 +2073,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2078,7 +2212,7 @@ dependencies = [
  "socket2 0.5.10",
  "widestring",
  "windows-sys 0.48.0",
- "winreg",
+ "winreg 0.50.0",
 ]
 
 [[package]]
@@ -2671,7 +2805,7 @@ checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 [[package]]
 name = "litep2p"
 version = "0.12.3"
-source = "git+https://github.com/paritytech/litep2p?branch=master#772840b1c53dc88a0b6f0808c73e7470442f2f95"
+source = "git+https://github.com/paritytech/litep2p?branch=master#ba3d7bd9678804bf7e5782363fe99b4a6ffe9d7b"
 dependencies = [
  "async-trait",
  "bs58",
@@ -2855,6 +2989,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -2979,6 +3114,7 @@ dependencies = [
  "digest 0.10.7",
  "multihash-derive",
  "sha2 0.10.9",
+ "sha3",
  "unsigned-varint 0.7.2",
 ]
 
@@ -3630,9 +3766,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
 dependencies = [
  "unicode-ident",
 ]
@@ -3820,9 +3956,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.39"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
+checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
 dependencies = [
  "proc-macro2",
 ]
@@ -4130,6 +4266,7 @@ version = "0.23.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -4461,6 +4598,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
 name = "simple-dns"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4554,8 +4697,11 @@ dependencies = [
 name = "smoldot-automation"
 version = "0.1.0"
 dependencies = [
+ "headless_chrome",
  "rouille",
  "serde",
+ "tracing",
+ "tracing-subscriber",
  "utils",
 ]
 
@@ -4641,6 +4787,17 @@ checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -5060,7 +5217,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite",
+ "tungstenite 0.27.0",
 ]
 
 [[package]]
@@ -5181,6 +5338,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "sha1",
+ "thiserror 2.0.17",
+ "utf-8",
+]
+
+[[package]]
 name = "turn"
 version = "0.10.0"
 source = "git+https://github.com/haikoschol/webrtc.git?branch=always-send-ice-keepalives#d7a8da915be8517f4f49f9a2db7541e1f9d11703"
@@ -5288,6 +5462,36 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d39cb1dbab692d82a977c0392ffac19e188bd9186a9f32806f0aaa859d75585a"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "socks",
+ "ureq-proto",
+ "utf-8",
+ "webpki-roots 1.0.4",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "httparse",
+ "log",
+]
 
 [[package]]
 name = "url"
@@ -5767,6 +5971,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
+dependencies = [
+ "env_home",
+ "rustix 1.1.2",
+ "winsafe",
+]
+
+[[package]]
 name = "widestring"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6180,6 +6395,22 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "winreg"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,6 +65,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -131,9 +167,24 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
+dependencies = [
+ "nodrop",
+]
+
+[[package]]
+name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
 name = "asn1-rs"
@@ -144,7 +195,7 @@ dependencies = [
  "asn1-rs-derive 0.5.1",
  "asn1-rs-impl",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
  "thiserror 1.0.69",
@@ -160,7 +211,7 @@ dependencies = [
  "asn1-rs-derive 0.6.0",
  "asn1-rs-impl",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
  "thiserror 2.0.17",
@@ -203,6 +254,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -218,6 +281,17 @@ dependencies = [
  "rustix 1.1.2",
  "slab",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -245,6 +319,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-take"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8ab6b55fe97976e46f91ddbed8d147d966475dc29b2032757ba47e02376fbc3"
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,7 +336,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "http",
  "log",
  "url",
@@ -297,6 +377,12 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -317,6 +403,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bip39"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
+dependencies = [
+ "bitcoin_hashes",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
+dependencies = [
+ "hex-conservative",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,7 +438,17 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "blake2-rfc"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
+dependencies = [
+ "arrayvec 0.4.12",
+ "constant_time_eq 0.1.5",
 ]
 
 [[package]]
@@ -344,8 +458,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06e903a20b159e944f91ec8499fe1e55651480c541ea0a584f5d967c49ad9d99"
 dependencies = [
  "arrayref",
- "arrayvec",
- "constant_time_eq",
+ "arrayvec 0.7.6",
+ "constant_time_eq 0.3.1",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -367,12 +490,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
  "tinyvec",
+]
+
+[[package]]
+name = "buf_redux"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b953a6887648bb07a535631f2bc00fbdb2a2216f135552cb3f534ed136b9c07f"
+dependencies = [
+ "memchr",
+ "safemem",
 ]
 
 [[package]]
@@ -458,6 +612,23 @@ dependencies = [
  "poly1305",
  "zeroize",
 ]
+
+[[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "chunked_transfer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "cid"
@@ -555,6 +726,12 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
@@ -564,6 +741,15 @@ name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -628,6 +814,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -647,6 +842,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -687,6 +891,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -704,7 +918,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -749,6 +963,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "deflate"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c86f7e25f518f4b81808a2cf1c50996a61f5c2eb394b2393bd87f2a4780a432f"
+dependencies = [
+ "adler32",
+ "gzip-header",
+]
+
+[[package]]
 name = "der"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,7 +991,7 @@ checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
 dependencies = [
  "asn1-rs 0.6.2",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-bigint",
  "num-traits",
  "rusticata-macros",
@@ -781,7 +1005,7 @@ checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
  "asn1-rs 0.7.0",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-bigint",
  "num-traits",
  "rusticata-macros",
@@ -797,12 +1021,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case 0.10.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.99",
+ "unicode-xid",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid",
  "crypto-common",
  "subtle",
@@ -826,6 +1082,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dtoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,7 +1100,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -865,7 +1127,23 @@ dependencies = [
  "ed25519",
  "rand_core 0.6.4",
  "serde",
- "sha2",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-zebra"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0017d969298eec91e3db7a2985a8cab4df6341d86e6f3a6f5878b13fb7846bc9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "hashbrown",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -884,7 +1162,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -924,7 +1202,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4be2cf2fe7b971b1865febbacd4d8df544aa6bd377cca011a6d69dcf4c60d94"
 dependencies = [
- "convert_case",
+ "convert_case 0.6.0",
  "quote",
  "syn 1.0.109",
 ]
@@ -943,6 +1221,26 @@ checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -966,6 +1264,18 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "filetime"
+version = "0.2.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "fixedbitset"
@@ -1176,22 +1486,31 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.13.3+wasi-0.2.2",
+ "r-efi",
+ "wasip2",
  "wasm-bindgen",
- "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "getrandom_or_panic"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea1015b5a70616b688dc230cfe50c8af89d972cb132d5a622814d29773b10b9"
+dependencies = [
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1222,6 +1541,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "gzip-header"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95cc527b92e6029a62960ad99aa8a6660faa4555fe5f731aab13aa6a921795a2"
+dependencies = [
+ "crc32fast",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1246,7 +1574,10 @@ version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
+ "serde",
 ]
 
 [[package]]
@@ -1275,6 +1606,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-conservative"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+dependencies = [
+ "arrayvec 0.7.6",
+]
 
 [[package]]
 name = "hickory-proto"
@@ -1329,7 +1669,17 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hmac"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -1338,7 +1688,18 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac-drbg"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
+dependencies = [
+ "digest 0.9.0",
+ "generic-array",
+ "hmac 0.8.1",
 ]
 
 [[package]]
@@ -1393,6 +1754,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1433,6 +1800,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1719,12 +2110,21 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+dependencies = [
+ "cpufeatures",
 ]
 
 [[package]]
@@ -1738,6 +2138,12 @@ name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libp2p"
@@ -1864,7 +2270,7 @@ dependencies = [
  "multihash 0.19.3",
  "quick-protobuf",
  "rand 0.8.5",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.17",
  "tracing",
  "zeroize",
@@ -1888,7 +2294,7 @@ dependencies = [
  "quick-protobuf",
  "quick-protobuf-codec",
  "rand 0.8.5",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.17",
  "tracing",
@@ -2146,7 +2552,7 @@ dependencies = [
  "quick-protobuf-codec",
  "rand 0.8.5",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "tinytemplate",
  "tracing",
 ]
@@ -2183,6 +2589,65 @@ dependencies = [
  "tracing",
  "yamux 0.12.1",
  "yamux 0.13.8",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+dependencies = [
+ "bitflags 2.9.0",
+ "libc",
+ "redox_syscall 0.7.0",
+]
+
+[[package]]
+name = "libsecp256k1"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79019718125edc905a079a70cfa5f3820bc76139fc91d6f9abc27ea2a887139"
+dependencies = [
+ "arrayref",
+ "base64 0.22.1",
+ "digest 0.9.0",
+ "hmac-drbg",
+ "libsecp256k1-core",
+ "libsecp256k1-gen-ecmult",
+ "libsecp256k1-gen-genmult",
+ "rand 0.8.5",
+ "serde",
+ "sha2 0.9.9",
+ "typenum",
+]
+
+[[package]]
+name = "libsecp256k1-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be9b9bb642d8522a44d533eab56c16c738301965504753b03ad1de3425d5451"
+dependencies = [
+ "crunchy",
+ "digest 0.9.0",
+ "subtle",
+]
+
+[[package]]
+name = "libsecp256k1-gen-ecmult"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3038c808c55c87e8a172643a7d87187fc6c4174468159cb3090659d55bcb4809"
+dependencies = [
+ "libsecp256k1-core",
+]
+
+[[package]]
+name = "libsecp256k1-gen-genmult"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db8d6ba2cec9eacc40e6e8ccc98931840301f1006e95647ceb2dd5c3aa06f7c"
+dependencies = [
+ "libsecp256k1-core",
 ]
 
 [[package]]
@@ -2229,7 +2694,7 @@ dependencies = [
  "prost-build",
  "rand 0.8.5",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "simple-dns",
  "smallvec",
  "snow",
@@ -2295,6 +2760,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2322,7 +2796,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2338,6 +2812,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "merlin"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
+dependencies = [
+ "byteorder",
+ "keccak",
+ "rand_core 0.6.4",
+ "zeroize",
+]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
 ]
 
 [[package]]
@@ -2362,7 +2864,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.52.0",
 ]
 
@@ -2410,6 +2912,12 @@ dependencies = [
  "thiserror 1.0.69",
  "uuid",
 ]
+
+[[package]]
+name = "multi-stash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685a9ac4b61f4e728e1d2c6a7844609c16527aeb5e6c865915c08e619c16410f"
 
 [[package]]
 name = "multiaddr"
@@ -2468,9 +2976,9 @@ checksum = "835d6ff01d610179fbce3de1694d007e500bf33a7f29689838941d6bf783ae40"
 dependencies = [
  "blake2b_simd",
  "core2",
- "digest",
+ "digest 0.10.7",
  "multihash-derive",
- "sha2",
+ "sha2 0.10.9",
  "unsigned-varint 0.7.2",
 ]
 
@@ -2503,6 +3011,24 @@ name = "multimap"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
+
+[[package]]
+name = "multipart"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00dec633863867f29cb39df64a397cdf4a6354708ddd7759f70c7fb51c5f9182"
+dependencies = [
+ "buf_redux",
+ "httparse",
+ "log",
+ "mime",
+ "mime_guess",
+ "quick-error",
+ "rand 0.8.5",
+ "safemem",
+ "tempfile",
+ "twoway",
+]
 
 [[package]]
 name = "multistream-select"
@@ -2607,6 +3133,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nodrop"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2620,6 +3152,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2658,6 +3199,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2673,6 +3225,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
  "libc",
 ]
 
@@ -2788,7 +3349,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2800,7 +3361,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2827,7 +3388,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.9",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -2839,12 +3400,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -3220,7 +3790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
  "bytes",
- "getrandom 0.3.1",
+ "getrandom 0.3.4",
  "lru-slab",
  "rand 0.9.2",
  "ring",
@@ -3256,6 +3826,12 @@ checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -3313,7 +3889,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.1",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3335,6 +3911,15 @@ name = "redox_syscall"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f"
+dependencies = [
+ "bitflags 2.9.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -3399,7 +3984,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -3415,6 +4000,30 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rouille"
+version = "3.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3716fbf57fc1084d7a706adf4e445298d123e4a44294c4e8213caf1b85fcc921"
+dependencies = [
+ "base64 0.13.1",
+ "brotli",
+ "chrono",
+ "deflate",
+ "filetime",
+ "multipart",
+ "percent-encoding",
+ "rand 0.8.5",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha1_smol",
+ "threadpool",
+ "time",
+ "tiny_http",
+ "url",
 ]
 
 [[package]]
@@ -3486,7 +4095,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -3568,6 +4177,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
+name = "ruzstd"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ff0cc5e135c8870a775d3320910cd9b564ec036b4dc0b8741629020be63f01"
+
+[[package]]
 name = "rw-stream-sink"
 version = "0.4.0"
 source = "git+https://github.com/ChainSafe/rust-libp2p?rev=6accaf64eec35cffc2807af6b3b1eba10303058d#6accaf64eec35cffc2807af6b3b1eba10303058d"
@@ -3584,12 +4199,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "safemem"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
+
+[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "schnorrkel"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9fcb6c2e176e86ec703e22560d99d65a5ee9056ae45a08e13e84ebf796296f"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.7.6",
+ "curve25519-dalek",
+ "getrandom_or_panic",
+ "merlin",
+ "rand_core 0.6.4",
+ "serde_bytes",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3684,6 +4323,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3724,7 +4373,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
  "sha1-asm",
 ]
 
@@ -3738,6 +4387,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
+name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3745,7 +4413,17 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest 0.10.7",
+ "keccak",
 ]
 
 [[package]]
@@ -3778,7 +4456,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -3790,6 +4468,12 @@ checksum = "f8cba3b4c122239e3b4473674cb7c79ad2693f008f0746bfe2fc3fe1ffcd936a"
 dependencies = [
  "bitflags 2.9.0",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
@@ -3816,6 +4500,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "smoldot"
+version = "0.19.4"
+source = "git+https://github.com/ChainSafe/smoldot?branch=haiko-webrtc-perf#04aee51e5d6f53f7bca3e971fdab62313a55bb12"
+dependencies = [
+ "arrayvec 0.7.6",
+ "async-lock",
+ "atomic-take",
+ "base64 0.22.1",
+ "bip39",
+ "blake2-rfc",
+ "bs58",
+ "chacha20",
+ "crossbeam-queue",
+ "derive_more",
+ "ed25519-zebra",
+ "either",
+ "event-listener",
+ "fnv",
+ "futures-lite",
+ "hashbrown",
+ "hex",
+ "hmac 0.12.1",
+ "itertools",
+ "libm",
+ "libsecp256k1",
+ "merlin",
+ "nom 8.0.0",
+ "num-bigint",
+ "num-rational",
+ "num-traits",
+ "pbkdf2",
+ "poly1305",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "ruzstd",
+ "schnorrkel",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sha3",
+ "siphasher",
+ "slab",
+ "smallvec",
+ "twox-hash",
+ "wasmi",
+ "web-sys",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
+name = "smoldot-automation"
+version = "0.1.0"
+dependencies = [
+ "rouille",
+ "serde",
+ "utils",
+]
+
+[[package]]
+name = "smoldot-light"
+version = "0.17.2"
+source = "git+https://github.com/ChainSafe/smoldot?branch=haiko-webrtc-perf#04aee51e5d6f53f7bca3e971fdab62313a55bb12"
+dependencies = [
+ "async-channel",
+ "async-lock",
+ "base64 0.22.1",
+ "blake2-rfc",
+ "bs58",
+ "derive_more",
+ "either",
+ "event-listener",
+ "fnv",
+ "futures-channel",
+ "futures-lite",
+ "futures-util",
+ "hashbrown",
+ "hex",
+ "itertools",
+ "lru",
+ "pin-project",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "serde",
+ "serde_json",
+ "siphasher",
+ "slab",
+ "smoldot",
+ "zeroize",
+]
+
+[[package]]
+name = "smoldot-perf"
+version = "0.1.0"
+dependencies = [
+ "base64 0.22.1",
+ "getrandom 0.2.15",
+ "js-sys",
+ "rand 0.9.2",
+ "smoldot",
+ "smoldot-light",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "snow"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3828,7 +4619,7 @@ dependencies = [
  "rand_core 0.6.4",
  "ring",
  "rustc_version",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
 ]
 
@@ -3858,7 +4649,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e859df029d160cb88608f5d7df7fb4753fd20fdfb4de5644f3d8b8440841721"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures",
  "httparse",
@@ -3866,6 +4657,12 @@ dependencies = [
  "rand 0.8.5",
  "sha1",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"
@@ -3898,7 +4695,7 @@ dependencies = [
  "combine",
  "crc",
  "fastrand",
- "hmac",
+ "hmac 0.12.1",
  "libc",
  "once_cell",
  "openssl",
@@ -3921,7 +4718,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea256fb46a13f9204e9dee9982997b2c3097db175a9fddaa8350310d03c4d5a3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "crc",
  "lazy_static",
  "md-5",
@@ -3939,7 +4736,7 @@ name = "stun"
 version = "0.8.0"
 source = "git+https://github.com/haikoschol/webrtc.git?branch=always-send-ice-keepalives#d7a8da915be8517f4f49f9a2db7541e1f9d11703"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "crc",
  "lazy_static",
  "md-5",
@@ -4047,7 +4844,7 @@ checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
 dependencies = [
  "cfg-if",
  "fastrand",
- "getrandom 0.3.1",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 0.38.44",
  "windows-sys 0.59.0",
@@ -4110,6 +4907,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
 name = "time"
 version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4117,7 +4923,9 @@ checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -4138,6 +4946,18 @@ checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny_http"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "httpdate",
+ "log",
 ]
 
 [[package]]
@@ -4366,7 +5186,7 @@ version = "0.10.0"
 source = "git+https://github.com/haikoschol/webrtc.git?branch=always-send-ice-keepalives#d7a8da915be8517f4f49f9a2db7541e1f9d11703"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "futures",
  "log",
  "md-5",
@@ -4379,6 +5199,21 @@ dependencies = [
  "tokio-util",
  "webrtc-util 0.11.0",
 ]
+
+[[package]]
+name = "twoway"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"
@@ -4397,6 +5232,12 @@ dependencies = [
  "hex",
  "static_assertions",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -4496,7 +5337,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
- "getrandom 0.3.1",
+ "getrandom 0.3.4",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -4550,45 +5391,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasi"
-version = "0.13.3+wasi-0.2.2"
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.99",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.100"
+name = "wasm-bindgen-futures"
+version = "0.4.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4596,24 +5437,84 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn 2.0.99",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasmi"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19af97fcb96045dd1d6b4d23e2b4abdbbe81723dbc5c9f016eb52145b320063"
+dependencies = [
+ "arrayvec 0.7.6",
+ "multi-stash",
+ "smallvec",
+ "spin",
+ "wasmi_collections",
+ "wasmi_core",
+ "wasmi_ir",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmi_collections"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e80d6b275b1c922021939d561574bf376613493ae2b61c6963b15db0e8813562"
+
+[[package]]
+name = "wasmi_core"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8c51482cc32d31c2c7ff211cd2bedd73c5bd057ba16a2ed0110e7a96097c33"
+dependencies = [
+ "downcast-rs",
+ "libm",
+]
+
+[[package]]
+name = "wasmi_ir"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e431a14c186db59212a88516788bd68ed51f87aa1e08d1df742522867b5289a"
+dependencies = [
+ "wasmi_core",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.221.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d06bfa36ab3ac2be0dee563380147a5b81ba10dd8885d7fbbc9eb574be67d185"
+dependencies = [
+ "bitflags 2.9.0",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4668,7 +5569,7 @@ dependencies = [
  "sdp",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smol_str",
  "stun 0.8.0",
  "thiserror 1.0.69",
@@ -4715,7 +5616,7 @@ dependencies = [
  "ccm",
  "der-parser 9.0.0",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "log",
  "p256",
  "p384",
@@ -4728,7 +5629,7 @@ dependencies = [
  "sec1",
  "serde",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "thiserror 1.0.69",
  "tokio",
@@ -4813,7 +5714,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "ctr",
- "hmac",
+ "hmac 0.12.1",
  "log",
  "rtcp",
  "rtp",
@@ -5281,13 +6182,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.33.0"
+name = "wit-bindgen"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
-dependencies = [
- "bitflags 2.9.0",
-]
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "write16"
@@ -5323,7 +6221,7 @@ dependencies = [
  "data-encoding",
  "der-parser 9.0.0",
  "lazy_static",
- "nom",
+ "nom 7.1.3",
  "oid-registry 0.7.1",
  "ring",
  "rusticata-macros",
@@ -5341,7 +6239,7 @@ dependencies = [
  "data-encoding",
  "der-parser 10.0.0",
  "lazy_static",
- "nom",
+ "nom 7.1.3",
  "oid-registry 0.8.1",
  "rusticata-macros",
  "thiserror 2.0.17",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,12 +62,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,7 +163,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "time",
 ]
 
@@ -1153,15 +1147,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "generator"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1263,9 +1248,16 @@ version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown",
 ]
 
 [[package]]
@@ -1310,8 +1302,8 @@ dependencies = [
  "once_cell",
  "rand 0.9.2",
  "ring",
- "socket2",
- "thiserror 2.0.12",
+ "socket2 0.5.10",
+ "thiserror 2.0.17",
  "tinyvec",
  "tokio",
  "tracing",
@@ -1334,7 +1326,7 @@ dependencies = [
  "rand 0.9.2",
  "resolv-conf",
  "smallvec",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
 ]
@@ -1443,7 +1435,7 @@ dependencies = [
  "hyper",
  "libc",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -1664,9 +1656,9 @@ dependencies = [
 
 [[package]]
 name = "interceptor"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ab04c530fd82e414e40394cabe5f0ebfe30d119f10fe29d6e3561926af412e"
+checksum = "1ac0781c825d602095113772e389ef0607afcb869ae0e68a590d8e0799cdcef8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1679,7 +1671,7 @@ dependencies = [
  "tokio",
  "waitgroup",
  "webrtc-srtp",
- "webrtc-util",
+ "webrtc-util 0.11.0",
 ]
 
 [[package]]
@@ -1699,7 +1691,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2",
+ "socket2 0.5.10",
  "widestring",
  "windows-sys 0.48.0",
  "winreg",
@@ -1756,9 +1748,8 @@ checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libp2p"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce71348bf5838e46449ae240631117b487073d5f347c06d434caddcb91dceb5a"
+version = "0.56.1"
+source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
 dependencies = [
  "bytes",
  "either",
@@ -1786,14 +1777,13 @@ dependencies = [
  "multiaddr 0.18.2",
  "pin-project",
  "rw-stream-sink",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16ccf824ee859ca83df301e1c0205270206223fd4b1f2e512a693e1912a8f4a"
+source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -1803,8 +1793,7 @@ dependencies = [
 [[package]]
 name = "libp2p-connection-limits"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18b8b607cf3bfa2f8c57db9c7d8569a315d5cc0a282e6bfd5ebfc0a9840b2a0"
+source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -1814,8 +1803,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.43.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d28e2d2def7c344170f5c6450c0dbe3dfef655610dbfde2f6ac28a527abbe36"
+source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
 dependencies = [
  "either",
  "fnv",
@@ -1830,7 +1818,7 @@ dependencies = [
  "quick-protobuf",
  "rand 0.8.5",
  "rw-stream-sink",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "tracing",
  "unsigned-varint 0.8.0",
  "web-time",
@@ -1839,8 +1827,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b770c1c8476736ca98c578cba4b505104ff8e842c2876b528925f9766379f9a"
+source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
 dependencies = [
  "async-trait",
  "futures",
@@ -1855,8 +1842,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ab792a8b68fdef443a62155b01970c81c3aadab5e659621b063ef252a8e65e8"
+source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -1869,7 +1855,7 @@ dependencies = [
  "quick-protobuf",
  "quick-protobuf-codec",
  "smallvec",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "tracing",
 ]
 
@@ -1886,16 +1872,15 @@ dependencies = [
  "quick-protobuf",
  "rand 0.8.5",
  "sha2",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "tracing",
  "zeroize",
 ]
 
 [[package]]
 name = "libp2p-kad"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d3fd632a5872ec804d37e7413ceea20588f69d027a0fa3c46f82574f4dee60"
+version = "0.49.0"
+source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -1912,7 +1897,7 @@ dependencies = [
  "rand 0.8.5",
  "sha2",
  "smallvec",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "tracing",
  "uint",
  "web-time",
@@ -1921,8 +1906,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66872d0f1ffcded2788683f76931be1c52e27f343edb93bc6d0bcd8887be443"
+source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
 dependencies = [
  "futures",
  "hickory-proto",
@@ -1932,16 +1916,15 @@ dependencies = [
  "libp2p-swarm",
  "rand 0.8.5",
  "smallvec",
- "socket2",
+ "socket2 0.6.1",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "libp2p-metrics"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "805a555148522cb3414493a5153451910cb1a146c53ffbf4385708349baf62b7"
+version = "0.17.1"
+source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -1958,8 +1941,7 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.46.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc73eacbe6462a0eb92a6527cac6e63f02026e5407f8831bde8293f19217bfbf"
+source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -1972,7 +1954,7 @@ dependencies = [
  "rand 0.8.5",
  "snow",
  "static_assertions",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "tracing",
  "x25519-dalek",
  "zeroize",
@@ -1995,7 +1977,7 @@ dependencies = [
  "libp2p-webrtc",
  "libp2p-yamux",
  "rand 0.8.5",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2006,8 +1988,7 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74bb7fcdfd9fead4144a3859da0b49576f171a8c8c7c0bfc7c541921d25e60d3"
+source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
 dependencies = [
  "futures",
  "futures-timer",
@@ -2022,8 +2003,7 @@ dependencies = [
 [[package]]
 name = "libp2p-quic"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dc448b2de9f4745784e3751fe8bc6c473d01b8317edd5ababcb0dec803d843f"
+source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
 dependencies = [
  "futures",
  "futures-timer",
@@ -2035,8 +2015,8 @@ dependencies = [
  "rand 0.8.5",
  "ring",
  "rustls",
- "socket2",
- "thiserror 2.0.12",
+ "socket2 0.6.1",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
 ]
@@ -2044,8 +2024,7 @@ dependencies = [
 [[package]]
 name = "libp2p-request-response"
 version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f1cca83488b90102abac7b67d5c36fc65bc02ed47620228af7ed002e6a1478"
+source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
 dependencies = [
  "async-trait",
  "futures",
@@ -2061,17 +2040,16 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aa762e5215919a34e31c35d4b18bf2e18566ecab7f8a3d39535f4a3068f8b62"
+source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
 dependencies = [
  "either",
  "fnv",
  "futures",
  "futures-timer",
+ "hashlink",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm-derive",
- "lru",
  "multistream-select",
  "rand 0.8.5",
  "smallvec",
@@ -2083,8 +2061,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.35.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd297cf53f0cb3dee4d2620bb319ae47ef27c702684309f682bdb7e55a18ae9c"
+source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
 dependencies = [
  "heck",
  "quote",
@@ -2094,15 +2071,14 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65b4e030c52c46c8d01559b2b8ca9b7c4185f10576016853129ca1fe5cd1a644"
+source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
 dependencies = [
  "futures",
  "futures-timer",
  "if-watch",
  "libc",
  "libp2p-core",
- "socket2",
+ "socket2 0.6.1",
  "tokio",
  "tracing",
 ]
@@ -2110,8 +2086,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ff65a82e35375cbc31ebb99cacbbf28cb6c4fefe26bf13756ddcf708d40080"
+source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
 dependencies = [
  "futures",
  "futures-rustls",
@@ -2120,17 +2095,16 @@ dependencies = [
  "rcgen",
  "ring",
  "rustls",
- "rustls-webpki 0.103.3",
- "thiserror 2.0.12",
+ "rustls-webpki",
+ "thiserror 2.0.17",
  "x509-parser 0.17.0",
  "yasna",
 ]
 
 [[package]]
 name = "libp2p-upnp"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4757e65fe69399c1a243bbb90ec1ae5a2114b907467bf09f3575e899815bb8d3"
+version = "0.6.0"
+source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
 dependencies = [
  "futures",
  "futures-timer",
@@ -2143,9 +2117,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-webrtc"
-version = "0.9.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bc51d86236d33762bccf5015e4ece458c549476c362040d4e1e6f3615e41b0"
+version = "0.9.0-alpha.2"
+source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
 dependencies = [
  "async-trait",
  "futures",
@@ -2159,8 +2132,8 @@ dependencies = [
  "multihash 0.19.3",
  "rand 0.8.5",
  "rcgen",
- "stun",
- "thiserror 2.0.12",
+ "stun 0.7.0",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-util",
  "tracing",
@@ -2170,8 +2143,7 @@ dependencies = [
 [[package]]
 name = "libp2p-webrtc-utils"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490abff5ee5f9a7a77f0145c79cc97c76941231a3626f4dee18ebf2abb95618f"
+source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -2191,9 +2163,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-websocket"
-version = "0.45.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520e29066a48674c007bc11defe5dce49908c24cafd8fad2f5e1a6a8726ced53"
+version = "0.45.2"
+source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
 dependencies = [
  "either",
  "futures",
@@ -2204,7 +2175,7 @@ dependencies = [
  "pin-project-lite",
  "rw-stream-sink",
  "soketto",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "tracing",
  "url",
  "webpki-roots 0.26.11",
@@ -2213,13 +2184,12 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f15df094914eb4af272acf9adaa9e287baa269943f32ea348ba29cfb9bfc60d8"
+source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
 dependencies = [
  "either",
  "futures",
  "libp2p-core",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "tracing",
  "yamux 0.12.1",
  "yamux 0.13.5",
@@ -2239,9 +2209,8 @@ checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "litep2p"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c666ef772d123a7643323ad4979c30dd825e9c68ec1aa5b387a6c9a9871c11ea"
+version = "0.11.0"
+source = "git+https://github.com/timwu20/litep2p?rev=9fb09abd77f88450f673c40e51b57aa0c7f4d358#9fb09abd77f88450f673c40e51b57aa0c7f4d358"
 dependencies = [
  "async-trait",
  "bs58",
@@ -2267,9 +2236,9 @@ dependencies = [
  "simple-dns",
  "smallvec",
  "snow",
- "socket2",
+ "socket2 0.5.10",
  "str0m",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
@@ -2326,15 +2295,6 @@ dependencies = [
  "scoped-tls",
  "tracing",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "lru"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
-dependencies = [
- "hashbrown",
 ]
 
 [[package]]
@@ -2544,15 +2504,14 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 [[package]]
 name = "multistream-select"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0df8e5eec2298a62b326ee4f0d7fe1a6b90a09dfcf9df37b38f947a8c42f19"
+source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
 dependencies = [
  "bytes",
  "futures",
- "log",
  "pin-project",
  "smallvec",
- "unsigned-varint 0.7.2",
+ "tracing",
+ "unsigned-varint 0.8.0",
 ]
 
 [[package]]
@@ -2603,7 +2562,7 @@ dependencies = [
  "log",
  "netlink-packet-core",
  "netlink-sys",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2627,7 +2586,7 @@ checksum = "862f41f1276e7148fb597fc55ed8666423bebe045199a1298c3515a73ec5cdd9"
 dependencies = [
  "cc",
  "libc",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "winapi",
 ]
 
@@ -3108,9 +3067,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf41c1a7c32ed72abe5082fb19505b969095c12da9f5732a4bc9878757fd087c"
+checksum = "e4500adecd7af8e0e9f4dbce15cfee07ce913fbf6ad605cc468b83f2d531ee94"
 dependencies = [
  "dtoa",
  "itoa",
@@ -3120,9 +3079,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client-derive-encode"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
+checksum = "9adf1691c04c0a5ff46ff8f262b58beb07b0dbb61f96f9f54f6cbd82106ed87f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3199,13 +3158,12 @@ dependencies = [
 [[package]]
 name = "quick-protobuf-codec"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15a0580ab32b169745d7a39db2ba969226ca16738931be152a3209b409de2474"
+source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
 dependencies = [
  "asynchronous-codec",
  "bytes",
  "quick-protobuf",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "unsigned-varint 0.8.0",
 ]
 
@@ -3222,8 +3180,8 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
- "thiserror 2.0.12",
+ "socket2 0.5.10",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
 ]
@@ -3242,7 +3200,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3257,7 +3215,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -3433,13 +3391,13 @@ dependencies = [
 
 [[package]]
 name = "rtcp"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8306430fb118b7834bbee50e744dc34826eca1da2158657a3d6cbc70e24c2096"
+checksum = "e9689528bf3a9eb311fd938d05516dd546412f9ce4fffc8acfc1db27cc3dbf72"
 dependencies = [
  "bytes",
  "thiserror 1.0.69",
- "webrtc-util",
+ "webrtc-util 0.11.0",
 ]
 
 [[package]]
@@ -3462,9 +3420,9 @@ dependencies = [
 
 [[package]]
 name = "rtp"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e68baca5b6cb4980678713f0d06ef3a432aa642baefcbfd0f4dd2ef9eb5ab550"
+checksum = "c54733451a67d76caf9caa07a7a2cec6871ea9dda92a7847f98063d459200f4b"
 dependencies = [
  "bytes",
  "memchr",
@@ -3472,7 +3430,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "thiserror 1.0.69",
- "webrtc-util",
+ "webrtc-util 0.11.0",
 ]
 
 [[package]]
@@ -3520,14 +3478,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.23"
+version = "0.23.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
+checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
 dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -3555,17 +3513,6 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
-]
-
-[[package]]
-name = "rustls-webpki"
 version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
@@ -3584,8 +3531,7 @@ checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 [[package]]
 name = "rw-stream-sink"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c9026ff5d2f23da5e45bbc283f156383001bfb09c4e44256d02c1a685fe9a1"
+source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
 dependencies = [
  "futures",
  "pin-project",
@@ -3621,24 +3567,24 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sctp-proto"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4dea4fe3384a24652f065296ac333c810dfd0c5b39b98a2214762c16aaadc3c"
+checksum = "423139d8cca3021b9d800f084a711ba2d23b508ae71b33dba167f11ca33e54c7"
 dependencies = [
  "bytes",
  "crc",
- "fxhash",
  "log",
- "rand 0.8.5",
+ "rand 0.9.2",
+ "rustc-hash",
  "slab",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "sdp"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a526161f474ae94b966ba622379d939a8fe46c930eebbadb73e339622599d5"
+checksum = "4cd277015eada44a0bb810a4b84d3bf6e810573fa62fb442f457edf6a1087a69"
 dependencies = [
  "rand 0.8.5",
  "substring",
@@ -3744,9 +3690,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3848,6 +3794,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "soketto"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3886,9 +3842,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "str0m"
-version = "0.6.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6110f29fbdda0516ae4ca52b62d802fbb6f874275db717a340ebb0ddd86e51c"
+checksum = "26890ff5b60e33eb8bedcf44792fc459c8f348ecbf2658edb19477571e547ac2"
 dependencies = [
  "combine",
  "crc",
@@ -3901,7 +3857,6 @@ dependencies = [
  "sctp-proto",
  "serde",
  "sha1",
- "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -3927,7 +3882,26 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "url",
- "webrtc-util",
+ "webrtc-util 0.10.0",
+]
+
+[[package]]
+name = "stun"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dbc2bab375524093c143dc362a03fb6a1fb79e938391cdb21665688f88a088a"
+dependencies = [
+ "base64",
+ "crc",
+ "lazy_static",
+ "md-5",
+ "rand 0.8.5",
+ "ring",
+ "subtle",
+ "thiserror 1.0.69",
+ "tokio",
+ "url",
+ "webrtc-util 0.11.0",
 ]
 
 [[package]]
@@ -4048,11 +4022,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -4068,9 +4042,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4168,7 +4142,7 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2",
+ "socket2 0.5.10",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -4333,16 +4307,16 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "url",
  "utf-8",
 ]
 
 [[package]]
 name = "turn"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0044fdae001dd8a1e247ea6289abf12f4fcea1331a2364da512f9cd680bbd8cb"
+checksum = "3f5aea1116456e1da71c45586b87c72e3b43164fbf435eb93ff6aa475416a9a4"
 dependencies = [
  "async-trait",
  "base64",
@@ -4352,11 +4326,11 @@ dependencies = [
  "portable-atomic",
  "rand 0.8.5",
  "ring",
- "stun",
+ "stun 0.8.0",
  "thiserror 1.0.69",
  "tokio",
  "tokio-util",
- "webrtc-util",
+ "webrtc-util 0.11.0",
 ]
 
 [[package]]
@@ -4619,9 +4593,9 @@ dependencies = [
 
 [[package]]
 name = "webrtc"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30367074d9f18231d28a74fab0120856b2b665da108d71a12beab7185a36f97b"
+checksum = "24bab7195998d605c862772f90a452ba655b90a2f463c850ac032038890e367a"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4644,7 +4618,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smol_str",
- "stun",
+ "stun 0.8.0",
  "thiserror 1.0.69",
  "time",
  "tokio",
@@ -4658,14 +4632,14 @@ dependencies = [
  "webrtc-media",
  "webrtc-sctp",
  "webrtc-srtp",
- "webrtc-util",
+ "webrtc-util 0.11.0",
 ]
 
 [[package]]
 name = "webrtc-data"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec93b991efcd01b73c5b3503fa8adba159d069abe5785c988ebe14fcf8f05d1"
+checksum = "4e97b932854da633a767eff0cc805425a2222fc6481e96f463e57b015d949d1d"
 dependencies = [
  "bytes",
  "log",
@@ -4673,14 +4647,14 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "webrtc-sctp",
- "webrtc-util",
+ "webrtc-util 0.11.0",
 ]
 
 [[package]]
 name = "webrtc-dtls"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c9b89fc909f9da0499283b1112cd98f72fec28e55a54a9e352525ca65cd95c"
+checksum = "5ccbe4d9049390ab52695c3646c1395c877e16c15fb05d3bda8eee0c7351711c"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -4708,16 +4682,16 @@ dependencies = [
  "subtle",
  "thiserror 1.0.69",
  "tokio",
- "webrtc-util",
+ "webrtc-util 0.11.0",
  "x25519-dalek",
  "x509-parser 0.16.0",
 ]
 
 [[package]]
 name = "webrtc-ice"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0348b28b593f7709ac98d872beb58c0009523df652c78e01b950ab9c537ff17d"
+checksum = "eb51bde0d790f109a15bfe4d04f1b56fb51d567da231643cb3f21bb74d678997"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4727,7 +4701,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "stun",
+ "stun 0.8.0",
  "thiserror 1.0.69",
  "tokio",
  "turn",
@@ -4735,27 +4709,27 @@ dependencies = [
  "uuid",
  "waitgroup",
  "webrtc-mdns",
- "webrtc-util",
+ "webrtc-util 0.11.0",
 ]
 
 [[package]]
 name = "webrtc-mdns"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6dfe9686c6c9c51428da4de415cb6ca2dc0591ce2b63212e23fd9cccf0e316b"
+checksum = "979cc85259c53b7b620803509d10d35e2546fa505d228850cbe3f08765ea6ea8"
 dependencies = [
  "log",
- "socket2",
+ "socket2 0.5.10",
  "thiserror 1.0.69",
  "tokio",
- "webrtc-util",
+ "webrtc-util 0.11.0",
 ]
 
 [[package]]
 name = "webrtc-media"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e153be16b8650021ad3e9e49ab6e5fa9fb7f6d1c23c213fd8bbd1a1135a4c704"
+checksum = "80041211deccda758a3e19aa93d6b10bc1d37c9183b519054b40a83691d13810"
 dependencies = [
  "byteorder",
  "bytes",
@@ -4766,9 +4740,9 @@ dependencies = [
 
 [[package]]
 name = "webrtc-sctp"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5faf3846ec4b7e64b56338d62cbafe084aa79806b0379dff5cc74a8b7a2b3063"
+checksum = "07439c134425d51d2f10907aaf2f815fdfb587dce19fe94a4ae8b5faf2aae5ae"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4779,14 +4753,14 @@ dependencies = [
  "rand 0.8.5",
  "thiserror 1.0.69",
  "tokio",
- "webrtc-util",
+ "webrtc-util 0.11.0",
 ]
 
 [[package]]
 name = "webrtc-srtp"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771db9993712a8fb3886d5be4613ebf27250ef422bd4071988bf55f1ed1a64fa"
+checksum = "01e773f79b09b057ffbda6b03fe7b43403b012a240cf8d05d630674c3723b5bb"
 dependencies = [
  "aead",
  "aes",
@@ -4802,7 +4776,7 @@ dependencies = [
  "subtle",
  "thiserror 1.0.69",
  "tokio",
- "webrtc-util",
+ "webrtc-util 0.11.0",
 ]
 
 [[package]]
@@ -4810,6 +4784,27 @@ name = "webrtc-util"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1438a8fd0d69c5775afb4a71470af92242dbd04059c61895163aa3c1ef933375"
+dependencies = [
+ "async-trait",
+ "bitflags 1.3.2",
+ "bytes",
+ "ipnet",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix",
+ "portable-atomic",
+ "rand 0.8.5",
+ "thiserror 1.0.69",
+ "tokio",
+ "winapi",
+]
+
+[[package]]
+name = "webrtc-util"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64bfb10dbe6d762f80169ae07cf252bafa1f764b9594d140008a0231c0cdce58"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -4873,7 +4868,7 @@ dependencies = [
  "windows-collections",
  "windows-core 0.61.2",
  "windows-future",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-numerics",
 ]
 
@@ -4904,7 +4899,7 @@ checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings",
 ]
@@ -4916,7 +4911,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-threading",
 ]
 
@@ -4949,13 +4944,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-numerics"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -4973,7 +4974,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -4982,7 +4983,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -5013,6 +5014,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5036,11 +5046,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5049,7 +5076,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -5065,6 +5092,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5075,6 +5108,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5089,10 +5128,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5107,6 +5158,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5117,6 +5174,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5131,6 +5194,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5141,6 +5210,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winreg"
@@ -5216,7 +5291,7 @@ dependencies = [
  "nom",
  "oid-registry 0.8.1",
  "rusticata-macros",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "time",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2205,8 +2205,8 @@ checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "litep2p"
-version = "0.12.2"
-source = "git+https://github.com/ChainSafe/litep2p?rev=78d0b6da78aaf9bae8af1f58d427bdd139f36521#78d0b6da78aaf9bae8af1f58d427bdd139f36521"
+version = "0.12.3"
+source = "git+https://github.com/paritytech/litep2p?branch=master#772840b1c53dc88a0b6f0808c73e7470442f2f95"
 dependencies = [
  "async-trait",
  "bs58",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2205,8 +2205,8 @@ checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "litep2p"
-version = "0.12.0"
-source = "git+https://github.com/ChainSafe/litep2p?rev=9621e3ccda915882f0dc93b7c2ea46c80c0fea7a#9621e3ccda915882f0dc93b7c2ea46c80c0fea7a"
+version = "0.12.2"
+source = "git+https://github.com/ChainSafe/litep2p?rev=78d0b6da78aaf9bae8af1f58d427bdd139f36521#78d0b6da78aaf9bae8af1f58d427bdd139f36521"
 dependencies = [
  "async-trait",
  "bs58",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,32 +204,20 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.4.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
 dependencies = [
- "async-lock",
+ "autocfg",
  "cfg-if",
  "concurrent-queue",
  "futures-io",
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 1.1.2",
  "slab",
- "tracing",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "pin-project-lite",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -572,6 +560,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,9 +827,9 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "dtoa"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
+checksum = "d6add3b8cff394282be81f3fc1a0605db594ed69890078ca6e2cab1c408bcf04"
 
 [[package]]
 name = "ecdsa"
@@ -913,6 +910,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-display"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02058bb25d8d0605829af88230427dd5cd50661590bd2b09d1baf7c64c417f24"
+dependencies = [
+ "enum-display-macro",
+]
+
+[[package]]
+name = "enum-display-macro"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4be2cf2fe7b971b1865febbacd4d8df544aa6bd377cca011a6d69dcf4c60d94"
+dependencies = [
+ "convert_case",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -926,27 +943,6 @@ checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "event-listener"
-version = "5.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
-dependencies = [
- "event-listener",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -985,9 +981,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -1080,9 +1076,9 @@ checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -1191,8 +1187,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
+ "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
 
@@ -1268,15 +1266,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.9"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
-name = "hermit-abi"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1402,19 +1394,21 @@ checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
 
 [[package]]
 name = "hyper"
-version = "1.6.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
  "h2",
  "http",
  "http-body",
  "httparse",
  "itoa",
  "pin-project-lite",
+ "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1422,9 +1416,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.16"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
+checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1435,7 +1429,7 @@ dependencies = [
  "hyper",
  "libc",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -1749,7 +1743,7 @@ checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 [[package]]
 name = "libp2p"
 version = "0.56.1"
-source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
+source = "git+https://github.com/ChainSafe/rust-libp2p?rev=6accaf64eec35cffc2807af6b3b1eba10303058d#6accaf64eec35cffc2807af6b3b1eba10303058d"
 dependencies = [
  "bytes",
  "either",
@@ -1783,7 +1777,7 @@ dependencies = [
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.6.0"
-source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
+source = "git+https://github.com/ChainSafe/rust-libp2p?rev=6accaf64eec35cffc2807af6b3b1eba10303058d#6accaf64eec35cffc2807af6b3b1eba10303058d"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -1793,7 +1787,7 @@ dependencies = [
 [[package]]
 name = "libp2p-connection-limits"
 version = "0.6.0"
-source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
+source = "git+https://github.com/ChainSafe/rust-libp2p?rev=6accaf64eec35cffc2807af6b3b1eba10303058d#6accaf64eec35cffc2807af6b3b1eba10303058d"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -1803,7 +1797,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.43.1"
-source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
+source = "git+https://github.com/ChainSafe/rust-libp2p?rev=6accaf64eec35cffc2807af6b3b1eba10303058d#6accaf64eec35cffc2807af6b3b1eba10303058d"
 dependencies = [
  "either",
  "fnv",
@@ -1827,7 +1821,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.44.0"
-source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
+source = "git+https://github.com/ChainSafe/rust-libp2p?rev=6accaf64eec35cffc2807af6b3b1eba10303058d#6accaf64eec35cffc2807af6b3b1eba10303058d"
 dependencies = [
  "async-trait",
  "futures",
@@ -1842,7 +1836,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.47.0"
-source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
+source = "git+https://github.com/ChainSafe/rust-libp2p?rev=6accaf64eec35cffc2807af6b3b1eba10303058d#6accaf64eec35cffc2807af6b3b1eba10303058d"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -1880,7 +1874,7 @@ dependencies = [
 [[package]]
 name = "libp2p-kad"
 version = "0.49.0"
-source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
+source = "git+https://github.com/ChainSafe/rust-libp2p?rev=6accaf64eec35cffc2807af6b3b1eba10303058d#6accaf64eec35cffc2807af6b3b1eba10303058d"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -1906,7 +1900,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.48.0"
-source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
+source = "git+https://github.com/ChainSafe/rust-libp2p?rev=6accaf64eec35cffc2807af6b3b1eba10303058d#6accaf64eec35cffc2807af6b3b1eba10303058d"
 dependencies = [
  "futures",
  "hickory-proto",
@@ -1924,7 +1918,7 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.17.1"
-source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
+source = "git+https://github.com/ChainSafe/rust-libp2p?rev=6accaf64eec35cffc2807af6b3b1eba10303058d#6accaf64eec35cffc2807af6b3b1eba10303058d"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -1941,7 +1935,7 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.46.1"
-source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
+source = "git+https://github.com/ChainSafe/rust-libp2p?rev=6accaf64eec35cffc2807af6b3b1eba10303058d#6accaf64eec35cffc2807af6b3b1eba10303058d"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -1964,16 +1958,13 @@ dependencies = [
 name = "libp2p-perf"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "clap",
  "futures",
- "futures-bounded",
  "libp2p",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-noise",
  "libp2p-swarm",
- "libp2p-tls",
  "libp2p-webrtc",
  "libp2p-yamux",
  "rand 0.8.5",
@@ -1988,7 +1979,7 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.47.0"
-source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
+source = "git+https://github.com/ChainSafe/rust-libp2p?rev=6accaf64eec35cffc2807af6b3b1eba10303058d#6accaf64eec35cffc2807af6b3b1eba10303058d"
 dependencies = [
  "futures",
  "futures-timer",
@@ -2003,7 +1994,7 @@ dependencies = [
 [[package]]
 name = "libp2p-quic"
 version = "0.13.0"
-source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
+source = "git+https://github.com/ChainSafe/rust-libp2p?rev=6accaf64eec35cffc2807af6b3b1eba10303058d#6accaf64eec35cffc2807af6b3b1eba10303058d"
 dependencies = [
  "futures",
  "futures-timer",
@@ -2024,7 +2015,7 @@ dependencies = [
 [[package]]
 name = "libp2p-request-response"
 version = "0.29.0"
-source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
+source = "git+https://github.com/ChainSafe/rust-libp2p?rev=6accaf64eec35cffc2807af6b3b1eba10303058d#6accaf64eec35cffc2807af6b3b1eba10303058d"
 dependencies = [
  "async-trait",
  "futures",
@@ -2040,7 +2031,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.47.0"
-source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
+source = "git+https://github.com/ChainSafe/rust-libp2p?rev=6accaf64eec35cffc2807af6b3b1eba10303058d#6accaf64eec35cffc2807af6b3b1eba10303058d"
 dependencies = [
  "either",
  "fnv",
@@ -2061,7 +2052,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.35.1"
-source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
+source = "git+https://github.com/ChainSafe/rust-libp2p?rev=6accaf64eec35cffc2807af6b3b1eba10303058d#6accaf64eec35cffc2807af6b3b1eba10303058d"
 dependencies = [
  "heck",
  "quote",
@@ -2071,7 +2062,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.44.0"
-source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
+source = "git+https://github.com/ChainSafe/rust-libp2p?rev=6accaf64eec35cffc2807af6b3b1eba10303058d#6accaf64eec35cffc2807af6b3b1eba10303058d"
 dependencies = [
  "futures",
  "futures-timer",
@@ -2086,7 +2077,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.6.2"
-source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
+source = "git+https://github.com/ChainSafe/rust-libp2p?rev=6accaf64eec35cffc2807af6b3b1eba10303058d#6accaf64eec35cffc2807af6b3b1eba10303058d"
 dependencies = [
  "futures",
  "futures-rustls",
@@ -2104,7 +2095,7 @@ dependencies = [
 [[package]]
 name = "libp2p-upnp"
 version = "0.6.0"
-source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
+source = "git+https://github.com/ChainSafe/rust-libp2p?rev=6accaf64eec35cffc2807af6b3b1eba10303058d#6accaf64eec35cffc2807af6b3b1eba10303058d"
 dependencies = [
  "futures",
  "futures-timer",
@@ -2118,7 +2109,7 @@ dependencies = [
 [[package]]
 name = "libp2p-webrtc"
 version = "0.9.0-alpha.2"
-source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
+source = "git+https://github.com/ChainSafe/rust-libp2p?rev=6accaf64eec35cffc2807af6b3b1eba10303058d#6accaf64eec35cffc2807af6b3b1eba10303058d"
 dependencies = [
  "async-trait",
  "futures",
@@ -2143,7 +2134,7 @@ dependencies = [
 [[package]]
 name = "libp2p-webrtc-utils"
 version = "0.4.0"
-source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
+source = "git+https://github.com/ChainSafe/rust-libp2p?rev=6accaf64eec35cffc2807af6b3b1eba10303058d#6accaf64eec35cffc2807af6b3b1eba10303058d"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -2164,7 +2155,7 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket"
 version = "0.45.2"
-source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
+source = "git+https://github.com/ChainSafe/rust-libp2p?rev=6accaf64eec35cffc2807af6b3b1eba10303058d#6accaf64eec35cffc2807af6b3b1eba10303058d"
 dependencies = [
  "either",
  "futures",
@@ -2184,7 +2175,7 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.47.0"
-source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
+source = "git+https://github.com/ChainSafe/rust-libp2p?rev=6accaf64eec35cffc2807af6b3b1eba10303058d#6accaf64eec35cffc2807af6b3b1eba10303058d"
 dependencies = [
  "either",
  "futures",
@@ -2192,7 +2183,7 @@ dependencies = [
  "thiserror 2.0.17",
  "tracing",
  "yamux 0.12.1",
- "yamux 0.13.5",
+ "yamux 0.13.8",
 ]
 
 [[package]]
@@ -2202,6 +2193,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
 name = "litemap"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2209,14 +2206,15 @@ checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "litep2p"
-version = "0.11.0"
-source = "git+https://github.com/timwu20/litep2p?rev=9fb09abd77f88450f673c40e51b57aa0c7f4d358#9fb09abd77f88450f673c40e51b57aa0c7f4d358"
+version = "0.12.0"
+source = "git+https://github.com/ChainSafe/litep2p?rev=9621e3ccda915882f0dc93b7c2ea46c80c0fea7a#9621e3ccda915882f0dc93b7c2ea46c80c0fea7a"
 dependencies = [
  "async-trait",
  "bs58",
  "bytes",
  "cid",
  "ed25519-dalek",
+ "enum-display",
  "futures",
  "futures-timer",
  "hickory-resolver",
@@ -2228,7 +2226,7 @@ dependencies = [
  "network-interface",
  "parking_lot",
  "pin-project",
- "prost",
+ "prost 0.13.5",
  "prost-build",
  "rand 0.8.5",
  "serde",
@@ -2249,7 +2247,7 @@ dependencies = [
  "url",
  "x25519-dalek",
  "x509-parser 0.17.0",
- "yamux 0.13.5",
+ "yamux 0.13.8",
  "yasna",
  "zeroize",
 ]
@@ -2296,6 +2294,12 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "match_cfg"
@@ -2504,7 +2508,7 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 [[package]]
 name = "multistream-select"
 version = "0.13.0"
-source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
+source = "git+https://github.com/ChainSafe/rust-libp2p?rev=6accaf64eec35cffc2807af6b3b1eba10303058d#6accaf64eec35cffc2807af6b3b1eba10303058d"
 dependencies = [
  "bytes",
  "futures",
@@ -2665,11 +2669,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
 ]
 
@@ -2837,12 +2841,12 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem"
-version = "3.0.5"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2920,17 +2924,16 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polling"
-version = "3.7.4"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi 0.4.0",
+ "hermit-abi",
  "pin-project-lite",
- "rustix",
- "tracing",
- "windows-sys 0.59.0",
+ "rustix 1.1.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3095,14 +3098,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
+dependencies = [
+ "bytes",
+ "prost-derive 0.14.1",
 ]
 
 [[package]]
 name = "prost-build"
-version = "0.13.5"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
  "heck",
  "itertools",
@@ -3111,7 +3124,7 @@ dependencies = [
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost",
+ "prost 0.14.1",
  "prost-types",
  "regex",
  "syn 2.0.99",
@@ -3132,12 +3145,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-types"
-version = "0.13.5"
+name = "prost-derive"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
- "prost",
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
+dependencies = [
+ "prost 0.14.1",
 ]
 
 [[package]]
@@ -3158,7 +3184,7 @@ dependencies = [
 [[package]]
 name = "quick-protobuf-codec"
 version = "0.3.1"
-source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
+source = "git+https://github.com/ChainSafe/rust-libp2p?rev=6accaf64eec35cffc2807af6b3b1eba10303058d#6accaf64eec35cffc2807af6b3b1eba10303058d"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -3169,32 +3195,35 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.6"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
+ "cfg_aliases",
  "futures-io",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.9"
+version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
  "bytes",
- "getrandom 0.2.15",
- "rand 0.8.5",
+ "getrandom 0.3.1",
+ "lru-slab",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3208,16 +3237,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.10"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e46f3055866785f6b92bc6164b76be02ca8f2eb4b002c0354b28cf4c119e5944"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3472,8 +3501,21 @@ dependencies = [
  "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags 2.9.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3531,7 +3573,7 @@ checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 [[package]]
 name = "rw-stream-sink"
 version = "0.4.0"
-source = "git+https://github.com/timwu20/rust-libp2p?rev=8bdee16f4dc345eb2a4d63246bb8739f16353cc3#8bdee16f4dc345eb2a4d63246bb8739f16353cc3"
+source = "git+https://github.com/ChainSafe/rust-libp2p?rev=6accaf64eec35cffc2807af6b3b1eba10303058d#6accaf64eec35cffc2807af6b3b1eba10303058d"
 dependencies = [
  "futures",
  "pin-project",
@@ -3637,18 +3679,28 @@ checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "serde"
-version = "1.0.218"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.218"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3657,14 +3709,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.142"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3735,9 +3788,9 @@ dependencies = [
 
 [[package]]
 name = "simple-dns"
-version = "0.9.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee851d0e5e7af3721faea1843e8015e820a234f81fda3dea9247e15bac9a86a"
+checksum = "f8cba3b4c122239e3b4473674cb7c79ad2693f008f0746bfe2fc3fe1ffcd936a"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -4001,7 +4054,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.1",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
  "windows-sys 0.59.0",
 ]
 
@@ -4358,6 +4411,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4579,14 +4638,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.2",
+ "webpki-roots 1.0.4",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
+checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5023,6 +5082,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5297,9 +5365,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.25"
+version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b940ebc25896e71dd073bad2dbaa2abfe97b0a391415e22ad1326d9c54e3c4"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "xmltree"
@@ -5327,9 +5395,9 @@ dependencies = [
 
 [[package]]
 name = "yamux"
-version = "0.13.5"
+version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da1acad1c2dc53f0dde419115a38bd8221d8c3e47ae9aeceaf453266d29307e"
+checksum = "deab71f2e20691b4728b349c6cee8fc7223880fa67b6b4f92225ec32225447e5"
 dependencies = [
  "futures",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,6 @@ members = [
 ]
 
 resolver = "2"
+
+[patch.crates-io]
+webrtc = { git = "https://github.com/haikoschol/webrtc.git",  branch = "always-send-ice-keepalives" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@ members = [
     "libp2p",
     "litep2p",
     "utils",
+    "smoldot-perf",
+    "smoldot-automation",
 ]
 
 resolver = "2"

--- a/README.md
+++ b/README.md
@@ -114,47 +114,47 @@ cd litep2p
 
 ### Bandwidth
 
-| Operation  | Bytes  | Litep2p->Litep2p (TCP) | Libp2p->Libp2p (TCP) | Libp2p->Libp2p (WebRTC) | Libp2p->Litep2p (TCP) | Libp2p->Litep2p (WebRTC) | Litep2p->Libp2p (TCP) |
-|------------|--------|------------------------|----------------------|-------------------------|-----------------------|--------------------------|-----------------------|
-| Uploaded   | 1.0KiB | 3.98 Gbit/s            | 2.35 Gbit/s          | 563.06 Mbit/s           | 3.39 Gbit/s           | 452.90 Mbit/s            | 3.81 Gbit/s           |
-| Uploaded   | 2.0KiB | 5.91 Gbit/s            | 3.70 Gbit/s          | 1.24 Gbit/s             | 4.88 Gbit/s           | 539.56 Mbit/s            | 6.54 Gbit/s           |
-| Uploaded   | 4.0KiB | 4.73 Gbit/s            | 2.81 Gbit/s          | 1.95 Gbit/s             | 6.05 Gbit/s           | 641.58 Mbit/s            | 4.73 Gbit/s           |
-| Uploaded   | 8.0KiB | 10.10 Gbit/s           | 3.65 Gbit/s          | 2.27 Gbit/s             | 3.71 Gbit/s           | 354.69 Mbit/s            | 9.70 Gbit/s           |
-| Uploaded   | 16KiB  | 1001.33 Mbit/s         | 409.11 Mbit/s        | 1.62 Gbit/s             | 425.71 Mbit/s         | 784.52 Mbit/s            | 647.39 Mbit/s         |
-| Uploaded   | 32KiB  | 734.21 Mbit/s          | 323.24 Mbit/s        | 1.92 Gbit/s             | 329.58 Mbit/s         | 696.38 Mbit/s            | 521.65 Mbit/s         |
-| Uploaded   | 64KiB  | 426.85 Mbit/s          | 417.23 Mbit/s        | 1.89 Gbit/s             | 404.08 Mbit/s         | 804.18 Mbit/s            | 465.50 Mbit/s         |
-| Uploaded   | 128KiB | 385.00 Mbit/s          | 388.95 Mbit/s        | 2.06 Gbit/s             | 360.21 Mbit/s         | 673.44 Mbit/s            | 408.18 Mbit/s         |
-| Uploaded   | 256KiB | 379.18 Mbit/s          | 392.68 Mbit/s        | 83.72 Mbit/s            | 505.00 Mbit/s         | 49.55 Mbit/s             | 395.67 Mbit/s         |
-| Uploaded   | 512KiB | 476.20 Mbit/s          | 411.87 Mbit/s        | 43.52 Mbit/s            | 531.37 Mbit/s         | 41.83 Mbit/s             | 419.62 Mbit/s         |
-| Uploaded   | 1.0MiB | 465.22 Mbit/s          | 426.62 Mbit/s        | 40.60 Mbit/s            | 410.64 Mbit/s         | 36.77 Mbit/s             | 470.99 Mbit/s         |
-| Uploaded   | 2.0MiB | 518.01 Mbit/s          | 501.62 Mbit/s        | 35.07 Mbit/s            | 472.82 Mbit/s         | 33.27 Mbit/s             | 503.70 Mbit/s         |
-| Uploaded   | 4.0MiB | 680.79 Mbit/s          | 587.54 Mbit/s        | 33.75 Mbit/s            | 587.76 Mbit/s         | 33.46 Mbit/s             | 673.93 Mbit/s         |
-| Uploaded   | 8.0MiB | 802.99 Mbit/s          | 650.43 Mbit/s        | 32.92 Mbit/s            | 650.16 Mbit/s         | 33.60 Mbit/s             | 768.98 Mbit/s         |
-| Uploaded   | 16MiB  | 854.45 Mbit/s          | 703.67 Mbit/s        | 32.99 Mbit/s            | 685.35 Mbit/s         | 33.76 Mbit/s             | 787.97 Mbit/s         |
-| Uploaded   | 32MiB  | 921.60 Mbit/s          | 708.99 Mbit/s        | 32.72 Mbit/s            | 728.34 Mbit/s         | 33.68 Mbit/s             | 818.49 Mbit/s         |
-| Uploaded   | 64MiB  | 957.68 Mbit/s          | 710.41 Mbit/s        | 32.42 Mbit/s            | 730.43 Mbit/s         | 33.61 Mbit/s             | 836.55 Mbit/s         |
-| Uploaded   | 128MiB | 961.15 Mbit/s          | 717.94 Mbit/s        | 32.29 Mbit/s            | 749.60 Mbit/s         | 33.55 Mbit/s             | 852.71 Mbit/s         |
-| Uploaded   | 256MiB | 882.12 Mbit/s          | 719.77 Mbit/s        | 32.23 Mbit/s            | 761.55 Mbit/s         | 33.48 Mbit/s             | 858.93 Mbit/s         |
-| Uploaded   | 512MiB | 920.68 Mbit/s          | 716.89 Mbit/s        | 32.17 Mbit/s            | 763.27 Mbit/s         | 33.46 Mbit/s             | 860.74 Mbit/s         |
-| Uploaded   | 1.0GiB | 985.91 Mbit/s          | 712.41 Mbit/s        | 32.37 Mbit/s            | 766.33 Mbit/s         | n/a                      | 868.62 Mbit/s         |
-| Downloaded | 1.0KiB | 30.64 Mbit/s           | 36.34 Mbit/s         | 4.15 Mbit/s             | 29.32 Mbit/s          | 3.03 Mbit/s              | 27.98 Mbit/s          |
-| Downloaded | 2.0KiB | 49.42 Mbit/s           | 44.87 Mbit/s         | 7.21 Mbit/s             | 56.93 Mbit/s          | 3.08 Mbit/s              | 45.70 Mbit/s          |
-| Downloaded | 4.0KiB | 73.04 Mbit/s           | 81.47 Mbit/s         | 9.29 Mbit/s             | 86.36 Mbit/s          | 3.93 Mbit/s              | 88.12 Mbit/s          |
-| Downloaded | 8.0KiB | 112.38 Mbit/s          | 119.77 Mbit/s        | 9.18 Mbit/s             | 120.23 Mbit/s         | 3.81 Mbit/s              | 118.11 Mbit/s         |
-| Downloaded | 16KiB  | 281.27 Mbit/s          | 175.84 Mbit/s        | 9.30 Mbit/s             | 204.14 Mbit/s         | 5.53 Mbit/s              | 161.08 Mbit/s         |
-| Downloaded | 32KiB  | 267.69 Mbit/s          | 341.53 Mbit/s        | 10.42 Mbit/s            | 342.02 Mbit/s         | 7.12 Mbit/s              | 201.18 Mbit/s         |
-| Downloaded | 64KiB  | 271.50 Mbit/s          | 331.55 Mbit/s        | 12.16 Mbit/s            | 425.94 Mbit/s         | 8.29 Mbit/s              | 278.07 Mbit/s         |
-| Downloaded | 128KiB | 310.64 Mbit/s          | 355.65 Mbit/s        | 14.05 Mbit/s            | 363.56 Mbit/s         | 11.03 Mbit/s             | 336.00 Mbit/s         |
-| Downloaded | 256KiB | 375.84 Mbit/s          | 394.35 Mbit/s        | 18.58 Mbit/s            | 443.98 Mbit/s         | 18.84 Mbit/s             | 378.60 Mbit/s         |
-| Downloaded | 512KiB | 512.30 Mbit/s          | 463.59 Mbit/s        | 24.55 Mbit/s            | 495.57 Mbit/s         | 23.94 Mbit/s             | 436.09 Mbit/s         |
-| Downloaded | 1.0MiB | 540.09 Mbit/s          | 598.67 Mbit/s        | 26.51 Mbit/s            | 569.77 Mbit/s         | 29.25 Mbit/s             | 513.71 Mbit/s         |
-| Downloaded | 2.0MiB | 879.67 Mbit/s          | 645.99 Mbit/s        | 29.98 Mbit/s            | 836.44 Mbit/s         | 34.31 Mbit/s             | 642.60 Mbit/s         |
-| Downloaded | 4.0MiB | 982.02 Mbit/s          | 713.97 Mbit/s        | 31.21 Mbit/s            | 845.34 Mbit/s         | 35.21 Mbit/s             | 769.42 Mbit/s         |
-| Downloaded | 8.0MiB | 978.81 Mbit/s          | 748.43 Mbit/s        | 32.15 Mbit/s            | 879.50 Mbit/s         | 36.03 Mbit/s             | 744.14 Mbit/s         |
-| Downloaded | 16MiB  | 867.09 Mbit/s          | 711.13 Mbit/s        | 32.45 Mbit/s            | 831.28 Mbit/s         | 36.29 Mbit/s             | 740.03 Mbit/s         |
-| Downloaded | 32MiB  | 964.77 Mbit/s          | 719.94 Mbit/s        | 32.44 Mbit/s            | 849.40 Mbit/s         | 36.24 Mbit/s             | 726.23 Mbit/s         |
-| Downloaded | 64MiB  | 970.98 Mbit/s          | 716.00 Mbit/s        | 32.49 Mbit/s            | 841.98 Mbit/s         | 36.24 Mbit/s             | 748.07 Mbit/s         |
-| Downloaded | 128MiB | 933.48 Mbit/s          | 705.87 Mbit/s        | 32.45 Mbit/s            | 844.31 Mbit/s         | 36.62 Mbit/s             | 754.59 Mbit/s         |
-| Downloaded | 256MiB | 920.71 Mbit/s          | 707.10 Mbit/s        | 32.38 Mbit/s            | 850.48 Mbit/s         | 36.60 Mbit/s             | 750.82 Mbit/s         |
-| Downloaded | 512MiB | 951.07 Mbit/s          | 712.52 Mbit/s        | 32.45 Mbit/s            | 852.45 Mbit/s         | 36.40 Mbit/s             | 744.70 Mbit/s         |
-| Downloaded | 1.0GiB | 964.81 Mbit/s          | 700.56 Mbit/s        | 32.64 Mbit/s            | 849.49 Mbit/s         | n/a                      | 757.75 Mbit/s         |
+| Operation  | Bytes  | Litep2p->Litep2p (TCP) | Libp2p->Libp2p (TCP) | Libp2p->Libp2p (WebRTC) | Libp2p->Litep2p (TCP) | Libp2p->Litep2p (WebRTC) | Litep2p->Libp2p (TCP) | Smoldot -> Litep2p (WebRTC) |
+|------------|--------|------------------------|----------------------|-------------------------|-----------------------|--------------------------|-----------------------|-----------------------------|
+| Uploaded   | 1.0KiB | 3.98 Gbit/s            | 2.35 Gbit/s          | 563.06 Mbit/s           | 3.39 Gbit/s           | 452.90 Mbit/s            | 3.81 Gbit/s           | inf Gbit/s                  |
+| Uploaded   | 2.0KiB | 5.91 Gbit/s            | 3.70 Gbit/s          | 1.24 Gbit/s             | 4.88 Gbit/s           | 539.56 Mbit/s            | 6.54 Gbit/s           | 19.53 Mbit/s                |
+| Uploaded   | 4.0KiB | 4.73 Gbit/s            | 2.81 Gbit/s          | 1.95 Gbit/s             | 6.05 Gbit/s           | 641.58 Mbit/s            | 4.73 Gbit/s           | 78.12 Mbit/s                |
+| Uploaded   | 8.0KiB | 10.10 Gbit/s           | 3.65 Gbit/s          | 2.27 Gbit/s             | 3.71 Gbit/s           | 354.69 Mbit/s            | 9.70 Gbit/s           | 125.00 Mbit/s               |
+| Uploaded   | 16KiB  | 1001.33 Mbit/s         | 409.11 Mbit/s        | 1.62 Gbit/s             | 425.71 Mbit/s         | 784.52 Mbit/s            | 647.39 Mbit/s         | 178.57 Mbit/s               |
+| Uploaded   | 32KiB  | 734.21 Mbit/s          | 323.24 Mbit/s        | 1.92 Gbit/s             | 329.58 Mbit/s         | 696.38 Mbit/s            | 521.65 Mbit/s         | 357.14 Mbit/s               |
+| Uploaded   | 64KiB  | 426.85 Mbit/s          | 417.23 Mbit/s        | 1.89 Gbit/s             | 404.08 Mbit/s         | 804.18 Mbit/s            | 465.50 Mbit/s         | 294.12 Mbit/s               |
+| Uploaded   | 128KiB | 385.00 Mbit/s          | 388.95 Mbit/s        | 2.06 Gbit/s             | 360.21 Mbit/s         | 673.44 Mbit/s            | 408.18 Mbit/s         | 454.55 Mbit/s               |
+| Uploaded   | 256KiB | 379.18 Mbit/s          | 392.68 Mbit/s        | 83.72 Mbit/s            | 505.00 Mbit/s         | 49.55 Mbit/s             | 395.67 Mbit/s         | 1000.00 Mbit/s              |
+| Uploaded   | 512KiB | 476.20 Mbit/s          | 411.87 Mbit/s        | 43.52 Mbit/s            | 531.37 Mbit/s         | 41.83 Mbit/s             | 419.62 Mbit/s         | 1.26 Gbit/s                 |
+| Uploaded   | 1.0MiB | 465.22 Mbit/s          | 426.62 Mbit/s        | 40.60 Mbit/s            | 410.64 Mbit/s         | 36.77 Mbit/s             | 470.99 Mbit/s         | 1.00 Gbit/s                 |
+| Uploaded   | 2.0MiB | 518.01 Mbit/s          | 501.62 Mbit/s        | 35.07 Mbit/s            | 472.82 Mbit/s         | 33.27 Mbit/s             | 503.70 Mbit/s         | 792.08 Mbit/s               |
+| Uploaded   | 4.0MiB | 680.79 Mbit/s          | 587.54 Mbit/s        | 33.75 Mbit/s            | 587.76 Mbit/s         | 33.46 Mbit/s             | 673.93 Mbit/s         | 2.22 Gbit/s                 |
+| Uploaded   | 8.0MiB | 802.99 Mbit/s          | 650.43 Mbit/s        | 32.92 Mbit/s            | 650.16 Mbit/s         | 33.60 Mbit/s             | 768.98 Mbit/s         | 1.83 Gbit/s                 |
+| Uploaded   | 16MiB  | 854.45 Mbit/s          | 703.67 Mbit/s        | 32.99 Mbit/s            | 685.35 Mbit/s         | 33.76 Mbit/s             | 787.97 Mbit/s         | 389.18 Mbit/s               |
+| Uploaded   | 32MiB  | 921.60 Mbit/s          | 708.99 Mbit/s        | 32.72 Mbit/s            | 728.34 Mbit/s         | 33.68 Mbit/s             | 818.49 Mbit/s         | 398.32 Mbit/s               |
+| Uploaded   | 64MiB  | 957.68 Mbit/s          | 710.41 Mbit/s        | 32.42 Mbit/s            | 730.43 Mbit/s         | 33.61 Mbit/s             | 836.55 Mbit/s         | 338.45 Mbit/s               |
+| Uploaded   | 128MiB | 961.15 Mbit/s          | 717.94 Mbit/s        | 32.29 Mbit/s            | 749.60 Mbit/s         | 33.55 Mbit/s             | 852.71 Mbit/s         | 283.42 Mbit/s               |
+| Uploaded   | 256MiB | 882.12 Mbit/s          | 719.77 Mbit/s        | 32.23 Mbit/s            | 761.55 Mbit/s         | 33.48 Mbit/s             | 858.93 Mbit/s         | 259.09 Mbit/s               |
+| Uploaded   | 512MiB | 920.68 Mbit/s          | 716.89 Mbit/s        | 32.17 Mbit/s            | 763.27 Mbit/s         | 33.46 Mbit/s             | 860.74 Mbit/s         | 269.38 Mbit/s               |
+| Uploaded   | 1.0GiB | 985.91 Mbit/s          | 712.41 Mbit/s        | 32.37 Mbit/s            | 766.33 Mbit/s         | 32.76 Mbit/s             | 868.62 Mbit/s         | 255.45 Mbit/s               |
+| Downloaded | 1.0KiB | 30.64 Mbit/s           | 36.34 Mbit/s         | 4.15 Mbit/s             | 29.32 Mbit/s          | 3.03 Mbit/s              | 27.98 Mbit/s          | inf Gbit/s                  |
+| Downloaded | 2.0KiB | 49.42 Mbit/s           | 44.87 Mbit/s         | 7.21 Mbit/s             | 56.93 Mbit/s          | 3.08 Mbit/s              | 45.70 Mbit/s          | 78.12 Mbit/s                |
+| Downloaded | 4.0KiB | 73.04 Mbit/s           | 81.47 Mbit/s         | 9.29 Mbit/s             | 86.36 Mbit/s          | 3.93 Mbit/s              | 88.12 Mbit/s          | 104.17 Mbit/s               |
+| Downloaded | 8.0KiB | 112.38 Mbit/s          | 119.77 Mbit/s        | 9.18 Mbit/s             | 120.23 Mbit/s         | 3.81 Mbit/s              | 118.11 Mbit/s         | 48.04 Mbit/s                |
+| Downloaded | 16KiB  | 281.27 Mbit/s          | 175.84 Mbit/s        | 9.30 Mbit/s             | 204.14 Mbit/s         | 5.53 Mbit/s              | 161.08 Mbit/s         | 83.33 Mbit/s                |
+| Downloaded | 32KiB  | 267.69 Mbit/s          | 341.53 Mbit/s        | 10.42 Mbit/s            | 342.02 Mbit/s         | 7.12 Mbit/s              | 201.18 Mbit/s         | 50.00 Mbit/s                |
+| Downloaded | 64KiB  | 271.50 Mbit/s          | 331.55 Mbit/s        | 12.16 Mbit/s            | 425.94 Mbit/s         | 8.29 Mbit/s              | 278.07 Mbit/s         | 172.47 Mbit/s               |
+| Downloaded | 128KiB | 310.64 Mbit/s          | 355.65 Mbit/s        | 14.05 Mbit/s            | 363.56 Mbit/s         | 11.03 Mbit/s             | 336.00 Mbit/s         | 238.10 Mbit/s               |
+| Downloaded | 256KiB | 375.84 Mbit/s          | 394.35 Mbit/s        | 18.58 Mbit/s            | 443.98 Mbit/s         | 18.84 Mbit/s             | 378.60 Mbit/s         | 298.51 Mbit/s               |
+| Downloaded | 512KiB | 512.30 Mbit/s          | 463.59 Mbit/s        | 24.55 Mbit/s            | 495.57 Mbit/s         | 23.94 Mbit/s             | 436.09 Mbit/s         | 264.90 Mbit/s               |
+| Downloaded | 1.0MiB | 540.09 Mbit/s          | 598.67 Mbit/s        | 26.51 Mbit/s            | 569.77 Mbit/s         | 29.25 Mbit/s             | 513.71 Mbit/s         | 286.74 Mbit/s               |
+| Downloaded | 2.0MiB | 879.67 Mbit/s          | 645.99 Mbit/s        | 29.98 Mbit/s            | 836.44 Mbit/s         | 34.31 Mbit/s             | 642.60 Mbit/s         | 360.36 Mbit/s               |
+| Downloaded | 4.0MiB | 982.02 Mbit/s          | 713.97 Mbit/s        | 31.21 Mbit/s            | 845.34 Mbit/s         | 35.21 Mbit/s             | 769.42 Mbit/s         | 340.43 Mbit/s               |
+| Downloaded | 8.0MiB | 978.81 Mbit/s          | 748.43 Mbit/s        | 32.15 Mbit/s            | 879.50 Mbit/s         | 36.03 Mbit/s             | 744.14 Mbit/s         | 341.70 Mbit/s               |
+| Downloaded | 16MiB  | 867.09 Mbit/s          | 711.13 Mbit/s        | 32.45 Mbit/s            | 831.28 Mbit/s         | 36.29 Mbit/s             | 740.03 Mbit/s         | 348.30 Mbit/s               |
+| Downloaded | 32MiB  | 964.77 Mbit/s          | 719.94 Mbit/s        | 32.44 Mbit/s            | 849.40 Mbit/s         | 36.24 Mbit/s             | 726.23 Mbit/s         | 339.12 Mbit/s               |
+| Downloaded | 64MiB  | 970.98 Mbit/s          | 716.00 Mbit/s        | 32.49 Mbit/s            | 841.98 Mbit/s         | 36.24 Mbit/s             | 748.07 Mbit/s         | 342.84 Mbit/s               |
+| Downloaded | 128MiB | 933.48 Mbit/s          | 705.87 Mbit/s        | 32.45 Mbit/s            | 844.31 Mbit/s         | 36.62 Mbit/s             | 754.59 Mbit/s         | 342.31 Mbit/s               |
+| Downloaded | 256MiB | 920.71 Mbit/s          | 707.10 Mbit/s        | 32.38 Mbit/s            | 850.48 Mbit/s         | 36.60 Mbit/s             | 750.82 Mbit/s         | 335.09 Mbit/s               |
+| Downloaded | 512MiB | 951.07 Mbit/s          | 712.52 Mbit/s        | 32.45 Mbit/s            | 852.45 Mbit/s         | 36.40 Mbit/s             | 744.70 Mbit/s         | 351.47 Mbit/s               |
+| Downloaded | 1.0GiB | 964.81 Mbit/s          | 700.56 Mbit/s        | 32.64 Mbit/s            | 849.49 Mbit/s         | 52.48 Mbit/s             | 757.75 Mbit/s         | 340.65 Mbit/s               |

--- a/README.md
+++ b/README.md
@@ -114,48 +114,47 @@ cd litep2p
 
 ### Bandwidth
 
-| Operation  | Bytes      | Litep2p->Litep2p | Libp2p->Libp2p | Libp2p->Libp2p | Libp2p->Litep2p | Libp2p->Litep2p | Litep2p->Libp2p |
-|            |            | (TCP)            | (TCP)          | (WebRTC)       | (TCP)           | (WebRTC)        | (TCP)           |
-|------------|------------|------------------|----------------|----------------|-----------------|-----------------|-----------------|
-| Uploaded   | 1.0KiB | 3.46 Gbit/s | 3.16 Gbit/s | 1.17 Gbit/s | 4.36 Gbit/s | 225.36 Mbit/s | 3.74 Gbit/s |
-| Uploaded   | 2.0KiB | 9.39 Gbit/s | 5.23 Gbit/s | 796.18 Mbit/s | 1.85 Gbit/s | 429.06 Mbit/s | 2.54 Gbit/s |
-| Uploaded   | 4.0KiB | 2.15 Gbit/s | 6.37 Gbit/s | 1.23 Gbit/s | 8.05 Gbit/s | 370.01 Mbit/s | 3.45 Gbit/s |
-| Uploaded   | 8.0KiB | 7.11 Gbit/s | 5.09 Gbit/s | 1.46 Gbit/s | 5.66 Gbit/s | 515.82 Mbit/s | 5.79 Gbit/s |
-| Uploaded   | 16KiB | 838.46 Mbit/s | 373.74 Mbit/s | 1.68 Gbit/s | 391.24 Mbit/s | 532.77 Mbit/s | 800.64 Mbit/s |
-| Uploaded   | 32KiB | 555.92 Mbit/s | 348.37 Mbit/s | 1.69 Gbit/s | 299.48 Mbit/s | 1.20 Gbit/s | 453.10 Mbit/s |
-| Uploaded   | 64KiB | 436.65 Mbit/s | 353.20 Mbit/s | 1.74 Gbit/s | 538.50 Mbit/s | 1.73 Gbit/s | 432.45 Mbit/s |
-| Uploaded   | 128KiB | 357.14 Mbit/s | 388.14 Mbit/s | 3.45 Gbit/s | 341.68 Mbit/s | 681.16 Mbit/s | 414.52 Mbit/s |
-| Uploaded   | 256KiB | 482.24 Mbit/s | 323.69 Mbit/s | 51.57 Mbit/s | 321.55 Mbit/s | 60.10 Mbit/s | 349.15 Mbit/s |
-| Uploaded   | 512KiB | 420.43 Mbit/s | 349.45 Mbit/s | 47.77 Mbit/s | 393.10 Mbit/s | 46.43 Mbit/s | 362.95 Mbit/s |
-| Uploaded   | 1.0MiB | 452.06 Mbit/s | 382.80 Mbit/s | 34.42 Mbit/s | 405.66 Mbit/s | 35.68 Mbit/s | 396.46 Mbit/s |
-| Uploaded   | 2.0MiB | 476.54 Mbit/s | 468.72 Mbit/s | 33.50 Mbit/s | 454.18 Mbit/s | 33.54 Mbit/s | 484.36 Mbit/s |
-| Uploaded   | 4.0MiB | 602.35 Mbit/s | 542.05 Mbit/s | 32.51 Mbit/s | 529.74 Mbit/s | 31.15 Mbit/s | 595.09 Mbit/s |
-| Uploaded   | 8.0MiB | 731.84 Mbit/s | 597.95 Mbit/s | 32.05 Mbit/s | 587.44 Mbit/s | 31.37 Mbit/s | 723.80 Mbit/s |
-| Uploaded   | 16MiB | 745.03 Mbit/s | 616.75 Mbit/s | 31.83 Mbit/s | 617.36 Mbit/s | 30.80 Mbit/s | 756.98 Mbit/s |
-| Uploaded   | 32MiB | 753.37 Mbit/s | 631.18 Mbit/s | 31.65 Mbit/s | 644.45 Mbit/s | n/a | 778.50 Mbit/s |
-| Uploaded   | 64MiB | 806.63 Mbit/s | 635.26 Mbit/s | 31.68 Mbit/s | 632.70 Mbit/s | n/a | 784.85 Mbit/s |
-| Uploaded   | 128MiB | 879.59 Mbit/s | 635.71 Mbit/s | 31.03 Mbit/s | 637.97 Mbit/s | n/a | 764.72 Mbit/s |
-| Uploaded   | 256MiB | 867.99 Mbit/s | 643.30 Mbit/s | 31.42 Mbit/s | 698.84 Mbit/s | n/a | 803.06 Mbit/s |
-| Uploaded   | 512MiB | 871.38 Mbit/s | 652.90 Mbit/s | 31.16 Mbit/s | 620.08 Mbit/s | n/a | 808.02 Mbit/s |
-| Uploaded   | 1.0GiB | 882.42 Mbit/s | 643.92 Mbit/s | 31.39 Mbit/s | 630.04 Mbit/s | n/a | 813.40 Mbit/s |
-| Downloaded | 1.0KiB | 32.95 Mbit/s | 22.49 Mbit/s | 3.77 Mbit/s | 28.53 Mbit/s | 2.36 Mbit/s | 23.87 Mbit/s |
-| Downloaded | 2.0KiB | 63.92 Mbit/s | 50.13 Mbit/s | 4.88 Mbit/s | 52.36 Mbit/s | 3.45 Mbit/s | 45.08 Mbit/s |
-| Downloaded | 4.0KiB | 81.83 Mbit/s | 77.48 Mbit/s | 6.82 Mbit/s | 130.75 Mbit/s | 3.54 Mbit/s | 63.33 Mbit/s |
-| Downloaded | 8.0KiB | 141.94 Mbit/s | 102.54 Mbit/s | 7.62 Mbit/s | 114.75 Mbit/s | 3.58 Mbit/s | 100.94 Mbit/s |
-| Downloaded | 16KiB | 195.20 Mbit/s | 169.77 Mbit/s | 9.33 Mbit/s | 190.36 Mbit/s | 5.22 Mbit/s | 141.49 Mbit/s |
-| Downloaded | 32KiB | 197.94 Mbit/s | 288.42 Mbit/s | 10.47 Mbit/s | 252.40 Mbit/s | 6.81 Mbit/s | 196.53 Mbit/s |
-| Downloaded | 64KiB | 225.54 Mbit/s | 286.09 Mbit/s | 11.81 Mbit/s | 296.95 Mbit/s | 10.00 Mbit/s | 275.46 Mbit/s |
-| Downloaded | 128KiB | 297.69 Mbit/s | 325.77 Mbit/s | 13.88 Mbit/s | 327.18 Mbit/s | 11.41 Mbit/s | 278.86 Mbit/s |
-| Downloaded | 256KiB | 413.71 Mbit/s | 357.56 Mbit/s | 19.97 Mbit/s | 351.91 Mbit/s | 18.07 Mbit/s | 351.01 Mbit/s |
-| Downloaded | 512KiB | 408.00 Mbit/s | 405.74 Mbit/s | 22.14 Mbit/s | 399.83 Mbit/s | 22.16 Mbit/s | 400.23 Mbit/s |
-| Downloaded | 1.0MiB | 505.80 Mbit/s | 513.97 Mbit/s | 28.11 Mbit/s | 581.64 Mbit/s | n/a | 504.74 Mbit/s |
-| Downloaded | 2.0MiB | 777.57 Mbit/s | 638.82 Mbit/s | 29.31 Mbit/s | 775.99 Mbit/s | n/a | 666.08 Mbit/s |
-| Downloaded | 4.0MiB | 844.21 Mbit/s | 651.80 Mbit/s | 29.96 Mbit/s | 774.64 Mbit/s | n/a | 715.37 Mbit/s |
-| Downloaded | 8.0MiB | 792.89 Mbit/s | 641.97 Mbit/s | 31.05 Mbit/s | 784.99 Mbit/s | n/a | 683.01 Mbit/s |
-| Downloaded | 16MiB | 803.64 Mbit/s | 626.76 Mbit/s | 31.46 Mbit/s | 745.87 Mbit/s | n/a | 688.40 Mbit/s |
-| Downloaded | 32MiB | 779.37 Mbit/s | 633.95 Mbit/s | 31.48 Mbit/s | 760.55 Mbit/s | n/a | 691.93 Mbit/s |
-| Downloaded | 64MiB | 804.71 Mbit/s | 635.22 Mbit/s | 31.53 Mbit/s | 752.78 Mbit/s | n/a | 690.73 Mbit/s |
-| Downloaded | 128MiB | 862.24 Mbit/s | 637.05 Mbit/s | 31.18 Mbit/s | 782.09 Mbit/s | n/a | 621.61 Mbit/s |
-| Downloaded | 256MiB | 858.61 Mbit/s | 636.08 Mbit/s | 31.53 Mbit/s | 788.31 Mbit/s | n/a | 694.58 Mbit/s |
-| Downloaded | 512MiB | 861.56 Mbit/s | 637.50 Mbit/s | 31.19 Mbit/s | 738.45 Mbit/s | n/a | 692.77 Mbit/s |
-| Downloaded | 1.0GiB | 872.73 Mbit/s | 619.31 Mbit/s | 31.04 Mbit/s | 744.37 Mbit/s | n/a | 687.94 Mbit/s |
+| Operation  | Bytes  | Litep2p->Litep2p (TCP) | Libp2p->Libp2p (TCP) | Libp2p->Libp2p (WebRTC) | Libp2p->Litep2p (TCP) | Libp2p->Litep2p (WebRTC) | Litep2p->Libp2p (TCP) |
+|------------|--------|------------------------|----------------------|-------------------------|-----------------------|--------------------------|-----------------------|
+| Uploaded   | 1.0KiB | 3.98 Gbit/s            | 2.35 Gbit/s          | 563.06 Mbit/s           | 3.39 Gbit/s           | 452.90 Mbit/s            | 3.81 Gbit/s           |
+| Uploaded   | 2.0KiB | 5.91 Gbit/s            | 3.70 Gbit/s          | 1.24 Gbit/s             | 4.88 Gbit/s           | 539.56 Mbit/s            | 6.54 Gbit/s           |
+| Uploaded   | 4.0KiB | 4.73 Gbit/s            | 2.81 Gbit/s          | 1.95 Gbit/s             | 6.05 Gbit/s           | 641.58 Mbit/s            | 4.73 Gbit/s           |
+| Uploaded   | 8.0KiB | 10.10 Gbit/s           | 3.65 Gbit/s          | 2.27 Gbit/s             | 3.71 Gbit/s           | 354.69 Mbit/s            | 9.70 Gbit/s           |
+| Uploaded   | 16KiB  | 1001.33 Mbit/s         | 409.11 Mbit/s        | 1.62 Gbit/s             | 425.71 Mbit/s         | 784.52 Mbit/s            | 647.39 Mbit/s         |
+| Uploaded   | 32KiB  | 734.21 Mbit/s          | 323.24 Mbit/s        | 1.92 Gbit/s             | 329.58 Mbit/s         | 696.38 Mbit/s            | 521.65 Mbit/s         |
+| Uploaded   | 64KiB  | 426.85 Mbit/s          | 417.23 Mbit/s        | 1.89 Gbit/s             | 404.08 Mbit/s         | 804.18 Mbit/s            | 465.50 Mbit/s         |
+| Uploaded   | 128KiB | 385.00 Mbit/s          | 388.95 Mbit/s        | 2.06 Gbit/s             | 360.21 Mbit/s         | 673.44 Mbit/s            | 408.18 Mbit/s         |
+| Uploaded   | 256KiB | 379.18 Mbit/s          | 392.68 Mbit/s        | 83.72 Mbit/s            | 505.00 Mbit/s         | 49.55 Mbit/s             | 395.67 Mbit/s         |
+| Uploaded   | 512KiB | 476.20 Mbit/s          | 411.87 Mbit/s        | 43.52 Mbit/s            | 531.37 Mbit/s         | 41.83 Mbit/s             | 419.62 Mbit/s         |
+| Uploaded   | 1.0MiB | 465.22 Mbit/s          | 426.62 Mbit/s        | 40.60 Mbit/s            | 410.64 Mbit/s         | 36.77 Mbit/s             | 470.99 Mbit/s         |
+| Uploaded   | 2.0MiB | 518.01 Mbit/s          | 501.62 Mbit/s        | 35.07 Mbit/s            | 472.82 Mbit/s         | 33.27 Mbit/s             | 503.70 Mbit/s         |
+| Uploaded   | 4.0MiB | 680.79 Mbit/s          | 587.54 Mbit/s        | 33.75 Mbit/s            | 587.76 Mbit/s         | 33.46 Mbit/s             | 673.93 Mbit/s         |
+| Uploaded   | 8.0MiB | 802.99 Mbit/s          | 650.43 Mbit/s        | 32.92 Mbit/s            | 650.16 Mbit/s         | 33.60 Mbit/s             | 768.98 Mbit/s         |
+| Uploaded   | 16MiB  | 854.45 Mbit/s          | 703.67 Mbit/s        | 32.99 Mbit/s            | 685.35 Mbit/s         | 33.76 Mbit/s             | 787.97 Mbit/s         |
+| Uploaded   | 32MiB  | 921.60 Mbit/s          | 708.99 Mbit/s        | 32.72 Mbit/s            | 728.34 Mbit/s         | 33.68 Mbit/s             | 818.49 Mbit/s         |
+| Uploaded   | 64MiB  | 957.68 Mbit/s          | 710.41 Mbit/s        | 32.42 Mbit/s            | 730.43 Mbit/s         | 33.61 Mbit/s             | 836.55 Mbit/s         |
+| Uploaded   | 128MiB | 961.15 Mbit/s          | 717.94 Mbit/s        | 32.29 Mbit/s            | 749.60 Mbit/s         | 33.55 Mbit/s             | 852.71 Mbit/s         |
+| Uploaded   | 256MiB | 882.12 Mbit/s          | 719.77 Mbit/s        | 32.23 Mbit/s            | 761.55 Mbit/s         | 33.48 Mbit/s             | 858.93 Mbit/s         |
+| Uploaded   | 512MiB | 920.68 Mbit/s          | 716.89 Mbit/s        | 32.17 Mbit/s            | 763.27 Mbit/s         | 33.46 Mbit/s             | 860.74 Mbit/s         |
+| Uploaded   | 1.0GiB | 985.91 Mbit/s          | 712.41 Mbit/s        | 32.37 Mbit/s            | 766.33 Mbit/s         | n/a                      | 868.62 Mbit/s         |
+| Downloaded | 1.0KiB | 30.64 Mbit/s           | 36.34 Mbit/s         | 4.15 Mbit/s             | 29.32 Mbit/s          | 3.03 Mbit/s              | 27.98 Mbit/s          |
+| Downloaded | 2.0KiB | 49.42 Mbit/s           | 44.87 Mbit/s         | 7.21 Mbit/s             | 56.93 Mbit/s          | 3.08 Mbit/s              | 45.70 Mbit/s          |
+| Downloaded | 4.0KiB | 73.04 Mbit/s           | 81.47 Mbit/s         | 9.29 Mbit/s             | 86.36 Mbit/s          | 3.93 Mbit/s              | 88.12 Mbit/s          |
+| Downloaded | 8.0KiB | 112.38 Mbit/s          | 119.77 Mbit/s        | 9.18 Mbit/s             | 120.23 Mbit/s         | 3.81 Mbit/s              | 118.11 Mbit/s         |
+| Downloaded | 16KiB  | 281.27 Mbit/s          | 175.84 Mbit/s        | 9.30 Mbit/s             | 204.14 Mbit/s         | 5.53 Mbit/s              | 161.08 Mbit/s         |
+| Downloaded | 32KiB  | 267.69 Mbit/s          | 341.53 Mbit/s        | 10.42 Mbit/s            | 342.02 Mbit/s         | 7.12 Mbit/s              | 201.18 Mbit/s         |
+| Downloaded | 64KiB  | 271.50 Mbit/s          | 331.55 Mbit/s        | 12.16 Mbit/s            | 425.94 Mbit/s         | 8.29 Mbit/s              | 278.07 Mbit/s         |
+| Downloaded | 128KiB | 310.64 Mbit/s          | 355.65 Mbit/s        | 14.05 Mbit/s            | 363.56 Mbit/s         | 11.03 Mbit/s             | 336.00 Mbit/s         |
+| Downloaded | 256KiB | 375.84 Mbit/s          | 394.35 Mbit/s        | 18.58 Mbit/s            | 443.98 Mbit/s         | 18.84 Mbit/s             | 378.60 Mbit/s         |
+| Downloaded | 512KiB | 512.30 Mbit/s          | 463.59 Mbit/s        | 24.55 Mbit/s            | 495.57 Mbit/s         | 23.94 Mbit/s             | 436.09 Mbit/s         |
+| Downloaded | 1.0MiB | 540.09 Mbit/s          | 598.67 Mbit/s        | 26.51 Mbit/s            | 569.77 Mbit/s         | 29.25 Mbit/s             | 513.71 Mbit/s         |
+| Downloaded | 2.0MiB | 879.67 Mbit/s          | 645.99 Mbit/s        | 29.98 Mbit/s            | 836.44 Mbit/s         | 34.31 Mbit/s             | 642.60 Mbit/s         |
+| Downloaded | 4.0MiB | 982.02 Mbit/s          | 713.97 Mbit/s        | 31.21 Mbit/s            | 845.34 Mbit/s         | 35.21 Mbit/s             | 769.42 Mbit/s         |
+| Downloaded | 8.0MiB | 978.81 Mbit/s          | 748.43 Mbit/s        | 32.15 Mbit/s            | 879.50 Mbit/s         | 36.03 Mbit/s             | 744.14 Mbit/s         |
+| Downloaded | 16MiB  | 867.09 Mbit/s          | 711.13 Mbit/s        | 32.45 Mbit/s            | 831.28 Mbit/s         | 36.29 Mbit/s             | 740.03 Mbit/s         |
+| Downloaded | 32MiB  | 964.77 Mbit/s          | 719.94 Mbit/s        | 32.44 Mbit/s            | 849.40 Mbit/s         | 36.24 Mbit/s             | 726.23 Mbit/s         |
+| Downloaded | 64MiB  | 970.98 Mbit/s          | 716.00 Mbit/s        | 32.49 Mbit/s            | 841.98 Mbit/s         | 36.24 Mbit/s             | 748.07 Mbit/s         |
+| Downloaded | 128MiB | 933.48 Mbit/s          | 705.87 Mbit/s        | 32.45 Mbit/s            | 844.31 Mbit/s         | 36.62 Mbit/s             | 754.59 Mbit/s         |
+| Downloaded | 256MiB | 920.71 Mbit/s          | 707.10 Mbit/s        | 32.38 Mbit/s            | 850.48 Mbit/s         | 36.60 Mbit/s             | 750.82 Mbit/s         |
+| Downloaded | 512MiB | 951.07 Mbit/s          | 712.52 Mbit/s        | 32.45 Mbit/s            | 852.45 Mbit/s         | 36.40 Mbit/s             | 744.70 Mbit/s         |
+| Downloaded | 1.0GiB | 964.81 Mbit/s          | 700.56 Mbit/s        | 32.64 Mbit/s            | 849.49 Mbit/s         | n/a                      | 757.75 Mbit/s         |

--- a/README.md
+++ b/README.md
@@ -114,47 +114,48 @@ cd litep2p
 
 ### Bandwidth
 
-| Operation  | Bytes      | Litep2p->Litep2p | Libp2p->Libp2p | Libp2p->Litep2p | Litep2p->Libp2p |
-|------------|------------|------------------|----------------|-----------------|-----------------|
-| Uploaded   | 1,0KiB | 3.77 Gbit/s | 4.35 Gbit/s | 4.56 Gbit/s | 3.61 Gbit/s |
-| Uploaded   | 2,0KiB | 3.11 Gbit/s | 2.67 Gbit/s | 2.75 Gbit/s | 2.48 Gbit/s |
-| Uploaded   | 4,0KiB | 4.23 Gbit/s | 4.88 Gbit/s | 7.02 Gbit/s | 5.14 Gbit/s |
-| Uploaded   | 8,0KiB | 4.45 Gbit/s | 6.13 Gbit/s | 6.03 Gbit/s | 5.58 Gbit/s |
-| Uploaded   | 16KiB | 502.09 Mbit/s | 515.68 Mbit/s | 510.01 Mbit/s | 443.20 Mbit/s |
-| Uploaded   | 32KiB | 645.81 Mbit/s | 661.01 Mbit/s | 549.09 Mbit/s | 634.26 Mbit/s |
-| Uploaded   | 64KiB | 573.64 Mbit/s | 559.63 Mbit/s | 570.35 Mbit/s | 382.15 Mbit/s |
-| Uploaded   | 128KiB | 544.27 Mbit/s | 485.29 Mbit/s | 284.80 Mbit/s | 588.11 Mbit/s |
-| Uploaded   | 256KiB | 548.08 Mbit/s | 495.29 Mbit/s | 168.58 Mbit/s | 547.41 Mbit/s |
-| Uploaded   | 512KiB | 559.30 Mbit/s | 495.63 Mbit/s | 516.49 Mbit/s | 558.62 Mbit/s |
-| Uploaded   | 1,0MiB | 549.48 Mbit/s | 502.00 Mbit/s | 509.12 Mbit/s | 574.06 Mbit/s |
-| Uploaded   | 2,0MiB | 544.65 Mbit/s | 458.79 Mbit/s | 512.94 Mbit/s | 552.43 Mbit/s |
-| Uploaded   | 4,0MiB | 585.49 Mbit/s | 489.34 Mbit/s | 508.92 Mbit/s | 556.91 Mbit/s |
-| Uploaded   | 8,0MiB | 590.55 Mbit/s | 477.83 Mbit/s | 511.24 Mbit/s | 537.80 Mbit/s |
-| Uploaded   | 16MiB | 588.77 Mbit/s | 486.59 Mbit/s | 508.14 Mbit/s | 534.24 Mbit/s |
-| Uploaded   | 32MiB | 608.04 Mbit/s | 454.59 Mbit/s | 512.72 Mbit/s | 543.04 Mbit/s |
-| Uploaded   | 64MiB | 596.67 Mbit/s | 476.27 Mbit/s | 512.60 Mbit/s | 539.67 Mbit/s |
-| Uploaded   | 128MiB | 597.67 Mbit/s | 475.44 Mbit/s | 500.52 Mbit/s | 566.77 Mbit/s |
-| Uploaded   | 256MiB | 568.63 Mbit/s | 488.77 Mbit/s | 503.91 Mbit/s | 523.64 Mbit/s |
-| Uploaded   | 512MiB | 608.78 Mbit/s | 485.44 Mbit/s | 518.24 Mbit/s | 585.06 Mbit/s |
-| Uploaded   | 1,0GiB | 593.76 Mbit/s | 480.22 Mbit/s | 509.59 Mbit/s | 533.81 Mbit/s |
-| Downloaded | 1,0KiB | 37.52 Mbit/s | 32.47 Mbit/s | 27.34 Mbit/s | 32.32 Mbit/s |
-| Downloaded | 2,0KiB | 59.92 Mbit/s | 70.58 Mbit/s | 67.25 Mbit/s | 56.54 Mbit/s |
-| Downloaded | 4,0KiB | 104.13 Mbit/s | 107.57 Mbit/s | 62.26 Mbit/s | 103.77 Mbit/s |
-| Downloaded | 8,0KiB | 144.40 Mbit/s | 164.40 Mbit/s | 144.31 Mbit/s | 175.94 Mbit/s |
-| Downloaded | 16KiB | 226.44 Mbit/s | 244.50 Mbit/s | 234.40 Mbit/s | 192.15 Mbit/s |
-| Downloaded | 32KiB | 433.87 Mbit/s | 246.87 Mbit/s | 302.03 Mbit/s | 398.61 Mbit/s |
-| Downloaded | 64KiB | 398.39 Mbit/s | 391.43 Mbit/s | 319.19 Mbit/s | 348.72 Mbit/s |
-| Downloaded | 128KiB | 399.92 Mbit/s | 438.45 Mbit/s | 345.96 Mbit/s | 428.56 Mbit/s |
-| Downloaded | 256KiB | 553.59 Mbit/s | 417.66 Mbit/s | 355.77 Mbit/s | 475.05 Mbit/s |
-| Downloaded | 512KiB | 564.92 Mbit/s | 430.31 Mbit/s | 534.81 Mbit/s | 397.76 Mbit/s |
-| Downloaded | 1,0MiB | 576.16 Mbit/s | 421.55 Mbit/s | 549.70 Mbit/s | 414.19 Mbit/s |
-| Downloaded | 2,0MiB | 591.18 Mbit/s | 485.44 Mbit/s | 569.70 Mbit/s | 459.81 Mbit/s |
-| Downloaded | 4,0MiB | 585.57 Mbit/s | 428.47 Mbit/s | 490.32 Mbit/s | 502.02 Mbit/s |
-| Downloaded | 8,0MiB | 609.17 Mbit/s | 490.68 Mbit/s | 522.76 Mbit/s | 496.34 Mbit/s |
-| Downloaded | 16MiB | 601.63 Mbit/s | 480.64 Mbit/s | 543.31 Mbit/s | 500.06 Mbit/s |
-| Downloaded | 32MiB | 615.73 Mbit/s | 486.40 Mbit/s | 533.18 Mbit/s | 499.05 Mbit/s |
-| Downloaded | 64MiB | 609.44 Mbit/s | 485.17 Mbit/s | 557.61 Mbit/s | 505.44 Mbit/s |
-| Downloaded | 128MiB | 603.49 Mbit/s | 483.54 Mbit/s | 541.33 Mbit/s | 495.37 Mbit/s |
-| Downloaded | 256MiB | 600.82 Mbit/s | 488.18 Mbit/s | 564.84 Mbit/s | 497.95 Mbit/s |
-| Downloaded | 512MiB | 506.49 Mbit/s | 483.55 Mbit/s | 519.57 Mbit/s | 498.65 Mbit/s |
-| Downloaded | 1,0GiB | 601.71 Mbit/s | 485.35 Mbit/s | 543.15 Mbit/s | 500.86 Mbit/s |
+| Operation  | Bytes      | Litep2p->Litep2p | Libp2p->Libp2p | Libp2p->Libp2p | Libp2p->Litep2p | Libp2p->Litep2p | Litep2p->Libp2p |
+|            |            | (TCP)            | (TCP)          | (WebRTC)       | (TCP)           | (WebRTC)        | (TCP)           |
+|------------|------------|------------------|----------------|----------------|-----------------|-----------------|-----------------|
+| Uploaded   | 1.0KiB | 3.46 Gbit/s | 3.16 Gbit/s | 1.17 Gbit/s | 4.36 Gbit/s | 225.36 Mbit/s | 3.74 Gbit/s |
+| Uploaded   | 2.0KiB | 9.39 Gbit/s | 5.23 Gbit/s | 796.18 Mbit/s | 1.85 Gbit/s | 429.06 Mbit/s | 2.54 Gbit/s |
+| Uploaded   | 4.0KiB | 2.15 Gbit/s | 6.37 Gbit/s | 1.23 Gbit/s | 8.05 Gbit/s | 370.01 Mbit/s | 3.45 Gbit/s |
+| Uploaded   | 8.0KiB | 7.11 Gbit/s | 5.09 Gbit/s | 1.46 Gbit/s | 5.66 Gbit/s | 515.82 Mbit/s | 5.79 Gbit/s |
+| Uploaded   | 16KiB | 838.46 Mbit/s | 373.74 Mbit/s | 1.68 Gbit/s | 391.24 Mbit/s | 532.77 Mbit/s | 800.64 Mbit/s |
+| Uploaded   | 32KiB | 555.92 Mbit/s | 348.37 Mbit/s | 1.69 Gbit/s | 299.48 Mbit/s | 1.20 Gbit/s | 453.10 Mbit/s |
+| Uploaded   | 64KiB | 436.65 Mbit/s | 353.20 Mbit/s | 1.74 Gbit/s | 538.50 Mbit/s | 1.73 Gbit/s | 432.45 Mbit/s |
+| Uploaded   | 128KiB | 357.14 Mbit/s | 388.14 Mbit/s | 3.45 Gbit/s | 341.68 Mbit/s | 681.16 Mbit/s | 414.52 Mbit/s |
+| Uploaded   | 256KiB | 482.24 Mbit/s | 323.69 Mbit/s | 51.57 Mbit/s | 321.55 Mbit/s | 60.10 Mbit/s | 349.15 Mbit/s |
+| Uploaded   | 512KiB | 420.43 Mbit/s | 349.45 Mbit/s | 47.77 Mbit/s | 393.10 Mbit/s | 46.43 Mbit/s | 362.95 Mbit/s |
+| Uploaded   | 1.0MiB | 452.06 Mbit/s | 382.80 Mbit/s | 34.42 Mbit/s | 405.66 Mbit/s | 35.68 Mbit/s | 396.46 Mbit/s |
+| Uploaded   | 2.0MiB | 476.54 Mbit/s | 468.72 Mbit/s | 33.50 Mbit/s | 454.18 Mbit/s | 33.54 Mbit/s | 484.36 Mbit/s |
+| Uploaded   | 4.0MiB | 602.35 Mbit/s | 542.05 Mbit/s | 32.51 Mbit/s | 529.74 Mbit/s | 31.15 Mbit/s | 595.09 Mbit/s |
+| Uploaded   | 8.0MiB | 731.84 Mbit/s | 597.95 Mbit/s | 32.05 Mbit/s | 587.44 Mbit/s | 31.37 Mbit/s | 723.80 Mbit/s |
+| Uploaded   | 16MiB | 745.03 Mbit/s | 616.75 Mbit/s | 31.83 Mbit/s | 617.36 Mbit/s | 30.80 Mbit/s | 756.98 Mbit/s |
+| Uploaded   | 32MiB | 753.37 Mbit/s | 631.18 Mbit/s | 31.65 Mbit/s | 644.45 Mbit/s | n/a | 778.50 Mbit/s |
+| Uploaded   | 64MiB | 806.63 Mbit/s | 635.26 Mbit/s | 31.68 Mbit/s | 632.70 Mbit/s | n/a | 784.85 Mbit/s |
+| Uploaded   | 128MiB | 879.59 Mbit/s | 635.71 Mbit/s | 31.03 Mbit/s | 637.97 Mbit/s | n/a | 764.72 Mbit/s |
+| Uploaded   | 256MiB | 867.99 Mbit/s | 643.30 Mbit/s | 31.42 Mbit/s | 698.84 Mbit/s | n/a | 803.06 Mbit/s |
+| Uploaded   | 512MiB | 871.38 Mbit/s | 652.90 Mbit/s | 31.16 Mbit/s | 620.08 Mbit/s | n/a | 808.02 Mbit/s |
+| Uploaded   | 1.0GiB | 882.42 Mbit/s | 643.92 Mbit/s | 31.39 Mbit/s | 630.04 Mbit/s | n/a | 813.40 Mbit/s |
+| Downloaded | 1.0KiB | 32.95 Mbit/s | 22.49 Mbit/s | 3.77 Mbit/s | 28.53 Mbit/s | 2.36 Mbit/s | 23.87 Mbit/s |
+| Downloaded | 2.0KiB | 63.92 Mbit/s | 50.13 Mbit/s | 4.88 Mbit/s | 52.36 Mbit/s | 3.45 Mbit/s | 45.08 Mbit/s |
+| Downloaded | 4.0KiB | 81.83 Mbit/s | 77.48 Mbit/s | 6.82 Mbit/s | 130.75 Mbit/s | 3.54 Mbit/s | 63.33 Mbit/s |
+| Downloaded | 8.0KiB | 141.94 Mbit/s | 102.54 Mbit/s | 7.62 Mbit/s | 114.75 Mbit/s | 3.58 Mbit/s | 100.94 Mbit/s |
+| Downloaded | 16KiB | 195.20 Mbit/s | 169.77 Mbit/s | 9.33 Mbit/s | 190.36 Mbit/s | 5.22 Mbit/s | 141.49 Mbit/s |
+| Downloaded | 32KiB | 197.94 Mbit/s | 288.42 Mbit/s | 10.47 Mbit/s | 252.40 Mbit/s | 6.81 Mbit/s | 196.53 Mbit/s |
+| Downloaded | 64KiB | 225.54 Mbit/s | 286.09 Mbit/s | 11.81 Mbit/s | 296.95 Mbit/s | 10.00 Mbit/s | 275.46 Mbit/s |
+| Downloaded | 128KiB | 297.69 Mbit/s | 325.77 Mbit/s | 13.88 Mbit/s | 327.18 Mbit/s | 11.41 Mbit/s | 278.86 Mbit/s |
+| Downloaded | 256KiB | 413.71 Mbit/s | 357.56 Mbit/s | 19.97 Mbit/s | 351.91 Mbit/s | 18.07 Mbit/s | 351.01 Mbit/s |
+| Downloaded | 512KiB | 408.00 Mbit/s | 405.74 Mbit/s | 22.14 Mbit/s | 399.83 Mbit/s | 22.16 Mbit/s | 400.23 Mbit/s |
+| Downloaded | 1.0MiB | 505.80 Mbit/s | 513.97 Mbit/s | 28.11 Mbit/s | 581.64 Mbit/s | n/a | 504.74 Mbit/s |
+| Downloaded | 2.0MiB | 777.57 Mbit/s | 638.82 Mbit/s | 29.31 Mbit/s | 775.99 Mbit/s | n/a | 666.08 Mbit/s |
+| Downloaded | 4.0MiB | 844.21 Mbit/s | 651.80 Mbit/s | 29.96 Mbit/s | 774.64 Mbit/s | n/a | 715.37 Mbit/s |
+| Downloaded | 8.0MiB | 792.89 Mbit/s | 641.97 Mbit/s | 31.05 Mbit/s | 784.99 Mbit/s | n/a | 683.01 Mbit/s |
+| Downloaded | 16MiB | 803.64 Mbit/s | 626.76 Mbit/s | 31.46 Mbit/s | 745.87 Mbit/s | n/a | 688.40 Mbit/s |
+| Downloaded | 32MiB | 779.37 Mbit/s | 633.95 Mbit/s | 31.48 Mbit/s | 760.55 Mbit/s | n/a | 691.93 Mbit/s |
+| Downloaded | 64MiB | 804.71 Mbit/s | 635.22 Mbit/s | 31.53 Mbit/s | 752.78 Mbit/s | n/a | 690.73 Mbit/s |
+| Downloaded | 128MiB | 862.24 Mbit/s | 637.05 Mbit/s | 31.18 Mbit/s | 782.09 Mbit/s | n/a | 621.61 Mbit/s |
+| Downloaded | 256MiB | 858.61 Mbit/s | 636.08 Mbit/s | 31.53 Mbit/s | 788.31 Mbit/s | n/a | 694.58 Mbit/s |
+| Downloaded | 512MiB | 861.56 Mbit/s | 637.50 Mbit/s | 31.19 Mbit/s | 738.45 Mbit/s | n/a | 692.77 Mbit/s |
+| Downloaded | 1.0GiB | 872.73 Mbit/s | 619.31 Mbit/s | 31.04 Mbit/s | 744.37 Mbit/s | n/a | 687.94 Mbit/s |

--- a/libp2p/Cargo.toml
+++ b/libp2p/Cargo.toml
@@ -15,13 +15,15 @@ thiserror = "1.0"
 futures-bounded = "0.2.4"
 
 
-libp2p = { version = "0.54.1", features = ["dns", "identify", "kad", "macros", "mdns", "noise", "ping", "tcp",  "tokio", "yamux", "websocket", "request-response"] }
-libp2p-core = { version = "0.42" }
-libp2p-swarm = { version = "0.45.1" }
-libp2p-identity = { version = "0.2.9", features = ["ed25519", "peerid", "rand"] }
-libp2p-tls = "0.5.0"
-libp2p-noise = "0.45.0"
-libp2p-yamux = "0.46.0"
+libp2p = { version = "0.56.0", features = ["dns", "identify", "kad", "macros", "mdns", "noise", "ping", "tcp",  "tokio", "yamux", "websocket", "request-response"] }
+libp2p-core = { version = "0.43.1" }
+libp2p-swarm = { version = "0.47.0" }
+libp2p-identity = { version = "0.2.12", features = ["ed25519", "peerid", "rand"] }
+libp2p-tls = "0.6.2"
+libp2p-noise = "0.46.1"
+libp2p-webrtc = { version = "0.9.0-alpha.1", features = ["tokio"] }
+libp2p-yamux = "0.47.0"
 void = "1"
 
 utils = { path = "../utils" }
+rand = "0.8"

--- a/libp2p/Cargo.toml
+++ b/libp2p/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-async-trait = "0.1"
 clap = { version = "4.5.31", features = ["derive", "cargo"] }
 tokio = { version = "1.28", features = ["macros", "time", "rt-multi-thread"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
@@ -12,16 +11,15 @@ tracing = "0.1.34"
 futures = "0.3.28"
 
 thiserror = "2.0.16"
-futures-bounded = "0.2.4"
 
-libp2p = { git = "https://github.com/timwu20/rust-libp2p", rev = "8bdee16f4dc345eb2a4d63246bb8739f16353cc3", features = ["dns", "identify", "kad", "macros", "mdns", "noise", "ping", "tcp",  "tokio", "yamux", "websocket", "request-response"] }
-libp2p-core = { git = "https://github.com/timwu20/rust-libp2p", rev = "8bdee16f4dc345eb2a4d63246bb8739f16353cc3" }
-libp2p-swarm = { git = "https://github.com/timwu20/rust-libp2p", rev = "8bdee16f4dc345eb2a4d63246bb8739f16353cc3" }
+libp2p = { git = "https://github.com/ChainSafe/rust-libp2p", rev = "6accaf64eec35cffc2807af6b3b1eba10303058d", features = ["dns", "identify", "kad", "macros", "mdns", "noise", "ping", "tcp",  "tokio", "yamux", "websocket", "request-response"] }
+libp2p-core = { git = "https://github.com/ChainSafe/rust-libp2p", rev = "6accaf64eec35cffc2807af6b3b1eba10303058d" }
+libp2p-swarm = { git = "https://github.com/ChainSafe/rust-libp2p", rev = "6accaf64eec35cffc2807af6b3b1eba10303058d" }
 libp2p-identity = { version = "0.2.12", features = ["ed25519", "peerid", "rand"] }
-libp2p-tls = { git = "https://github.com/timwu20/rust-libp2p", rev = "8bdee16f4dc345eb2a4d63246bb8739f16353cc3" }
-libp2p-noise = { git = "https://github.com/timwu20/rust-libp2p", rev = "8bdee16f4dc345eb2a4d63246bb8739f16353cc3" }
-libp2p-webrtc = { git = "https://github.com/timwu20/rust-libp2p", rev = "8bdee16f4dc345eb2a4d63246bb8739f16353cc3", features = ["tokio"] }
-libp2p-yamux = { git = "https://github.com/timwu20/rust-libp2p", rev = "8bdee16f4dc345eb2a4d63246bb8739f16353cc3" }
+libp2p-noise = { git = "https://github.com/ChainSafe/rust-libp2p", rev = "6accaf64eec35cffc2807af6b3b1eba10303058d" }
+libp2p-webrtc = { git = "https://github.com/ChainSafe/rust-libp2p", rev = "6accaf64eec35cffc2807af6b3b1eba10303058d", features = ["tokio"] }
+libp2p-yamux = { git = "https://github.com/ChainSafe/rust-libp2p", rev = "6accaf64eec35cffc2807af6b3b1eba10303058d" }
+
 void = "1"
 
 utils = { path = "../utils" }

--- a/libp2p/Cargo.toml
+++ b/libp2p/Cargo.toml
@@ -11,18 +11,17 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing = "0.1.34"
 futures = "0.3.28"
 
-thiserror = "1.0"
+thiserror = "2.0.16"
 futures-bounded = "0.2.4"
 
-
-libp2p = { version = "0.56.0", features = ["dns", "identify", "kad", "macros", "mdns", "noise", "ping", "tcp",  "tokio", "yamux", "websocket", "request-response"] }
-libp2p-core = { version = "0.43.1" }
-libp2p-swarm = { version = "0.47.0" }
+libp2p = { git = "https://github.com/timwu20/rust-libp2p", rev = "8bdee16f4dc345eb2a4d63246bb8739f16353cc3", features = ["dns", "identify", "kad", "macros", "mdns", "noise", "ping", "tcp",  "tokio", "yamux", "websocket", "request-response"] }
+libp2p-core = { git = "https://github.com/timwu20/rust-libp2p", rev = "8bdee16f4dc345eb2a4d63246bb8739f16353cc3" }
+libp2p-swarm = { git = "https://github.com/timwu20/rust-libp2p", rev = "8bdee16f4dc345eb2a4d63246bb8739f16353cc3" }
 libp2p-identity = { version = "0.2.12", features = ["ed25519", "peerid", "rand"] }
-libp2p-tls = "0.6.2"
-libp2p-noise = "0.46.1"
-libp2p-webrtc = { version = "0.9.0-alpha.1", features = ["tokio"] }
-libp2p-yamux = "0.47.0"
+libp2p-tls = { git = "https://github.com/timwu20/rust-libp2p", rev = "8bdee16f4dc345eb2a4d63246bb8739f16353cc3" }
+libp2p-noise = { git = "https://github.com/timwu20/rust-libp2p", rev = "8bdee16f4dc345eb2a4d63246bb8739f16353cc3" }
+libp2p-webrtc = { git = "https://github.com/timwu20/rust-libp2p", rev = "8bdee16f4dc345eb2a4d63246bb8739f16353cc3", features = ["tokio"] }
+libp2p-yamux = { git = "https://github.com/timwu20/rust-libp2p", rev = "8bdee16f4dc345eb2a4d63246bb8739f16353cc3" }
 void = "1"
 
 utils = { path = "../utils" }

--- a/libp2p/src/client/handler.rs
+++ b/libp2p/src/client/handler.rs
@@ -139,14 +139,13 @@ impl ConnectionHandler for Handler {
             // TODO: remove when Rust 1.82 is MSRV
             #[allow(unreachable_patterns)]
             ConnectionEvent::ListenUpgradeError(ListenUpgradeError { info: (), error }) => {
-                // void::unreachable(error)
                 panic!("ListenUpgradeError should not occur in this context: {:?}", error);
             }
             _ => {}
         }
     }
 
-    #[tracing::instrument(level = "info", name = "ConnectionHandler::poll", skip(self, cx))]
+    #[tracing::instrument(level = "trace", name = "ConnectionHandler::poll", skip(self, cx))]
     fn poll(
         &mut self,
         cx: &mut Context<'_>,
@@ -156,7 +155,6 @@ impl ConnectionHandler for Handler {
         }
 
         if let Poll::Ready(Some((id, result))) = self.outbound.poll_next_unpin(cx) {
-            println!("Outbound result: {:?}", result);
             return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(Event {
                 id,
                 result: result.map_err(|err| err.to_string()),

--- a/libp2p/src/client/handler.rs
+++ b/libp2p/src/client/handler.rs
@@ -139,7 +139,10 @@ impl ConnectionHandler for Handler {
             // TODO: remove when Rust 1.82 is MSRV
             #[allow(unreachable_patterns)]
             ConnectionEvent::ListenUpgradeError(ListenUpgradeError { info: (), error }) => {
-                panic!("ListenUpgradeError should not occur in this context: {:?}", error);
+                panic!(
+                    "ListenUpgradeError should not occur in this context: {:?}",
+                    error
+                );
             }
             _ => {}
         }

--- a/libp2p/src/main.rs
+++ b/libp2p/src/main.rs
@@ -1,6 +1,11 @@
 use clap::Parser as ClapParser;
 use futures::StreamExt;
+use libp2p::PeerId;
 use libp2p_swarm::SwarmEvent;
+use rand::thread_rng;
+use libp2p::multiaddr::{Multiaddr, Protocol};
+use libp2p::core::{muxing::StreamMuxerBox, Transport};
+use std::net::Ipv4Addr;
 
 use utils::Command;
 
@@ -29,20 +34,53 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let local_key = libp2p::identity::ed25519::Keypair::from(secret_key);
             let local_key: libp2p::identity::Keypair = local_key.into();
 
-            let tcp_config = libp2p::tcp::Config::new().nodelay(true);
-            let mut swarm = libp2p::SwarmBuilder::with_existing_identity(local_key)
-                .with_tokio()
-                .with_tcp(
-                    tcp_config,
-                    libp2p_noise::Config::new,
-                    libp2p_yamux::Config::default,
-                )?
-                .with_dns()?
-                .with_behaviour(|_key| crate::server::behaviour::Behaviour::new())?
-                .with_swarm_config(|cfg| {
-                    cfg.with_idle_connection_timeout(std::time::Duration::from_secs(60))
-                })
-                .build();
+            let mut swarm = match server_opts.transport_layer {
+                utils::TransportLayer::Tcp => {
+                    let tcp_config = libp2p::tcp::Config::new().nodelay(true);
+                    libp2p::SwarmBuilder::with_existing_identity(local_key)
+                        .with_tokio()
+                        .with_tcp(
+                            tcp_config,
+                            libp2p_noise::Config::new,
+                            libp2p_yamux::Config::default,
+                        )?
+                        .with_dns()?
+                        .with_behaviour(|_key| crate::server::behaviour::Behaviour::new())?
+                        .with_swarm_config(|cfg| {
+                            cfg.with_idle_connection_timeout(std::time::Duration::from_secs(60))
+                        })
+                        .build()
+                }
+                utils::TransportLayer::WebSocket => {
+                    unimplemented!("WebSocket transport layer not implemented yet");
+                }
+                utils::TransportLayer::WebRTC => {
+
+                    let address_webrtc = Multiaddr::from(Ipv4Addr::UNSPECIFIED)
+                        .with(Protocol::Udp(0))
+                        .with(Protocol::WebRTCDirect);
+
+                    println!("Using WebRTC transport layer with address: {}", address_webrtc);
+
+
+                    libp2p::SwarmBuilder::with_existing_identity(local_key)
+                        .with_tokio()
+                        .with_other_transport(|key| {
+                            // libp2p_webrtc::tokio::Transport::new(key.clone(), Certificate::generate(&mut thread_rng()).unwrap())
+                            Ok(libp2p_webrtc::tokio::Transport::new(
+                                key.clone(),
+                                libp2p_webrtc::tokio::Certificate::generate(&mut thread_rng())?,
+                            )
+                            .map(|(peer_id, conn), _| (peer_id, StreamMuxerBox::new(conn))))
+                        })?
+                        // .with_dns()?
+                        .with_behaviour(|_key| crate::server::behaviour::Behaviour::new())?
+                        .with_swarm_config(|cfg| {
+                            cfg.with_idle_connection_timeout(std::time::Duration::from_secs(60))
+                        })
+                        .build()
+                }
+            };
 
             swarm.listen_on(server_opts.listen_address.parse()?)?;
 
@@ -75,23 +113,51 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     unimplemented!("WebSocket transport layer not implemented yet");
                 }
                 utils::TransportLayer::WebRTC => {
-                    unimplemented!("WebRTC transport layer not implemented yet");
+                    let mut swarm = libp2p::SwarmBuilder::with_existing_identity(local_key)
+                        .with_tokio()
+                        .with_other_transport(|key| {
+                            // libp2p_webrtc::tokio::Transport::new(key.clone(), Certificate::generate(&mut thread_rng()).unwrap())
+                            Ok(libp2p_webrtc::tokio::Transport::new(
+                                key.clone(),
+                                libp2p_webrtc::tokio::Certificate::generate(&mut thread_rng())?,
+                            )
+                            .map(|(peer_id, conn), _| (peer_id, StreamMuxerBox::new(conn))))
+                        })?
+                        // .with_dns()?
+                        .with_behaviour(|_key| crate::client::behaviour::Behaviour::new())?
+                        .with_swarm_config(|cfg| {
+                            cfg.with_idle_connection_timeout(std::time::Duration::from_secs(60))
+                        })
+                        .build();
+                    
+                    let listen_addr = "/ip4/0.0.0.0/udp/0/webrtc-direct".parse()?;
+                    swarm.listen_on(listen_addr)?;
+
+                    swarm
+
                 }
             };
 
             let addr: libp2p::Multiaddr = client_opts.server_address.parse()?;
             swarm.dial(addr)?;
 
-            let server_peer_id = match swarm.next().await.unwrap() {
-                SwarmEvent::ConnectionEstablished { peer_id, .. } => peer_id,
-                e => panic!("{e:?}"),
-            };
+            loop {
+                let event = swarm.next().await;
+                tracing::info!("Event: {:?}", event);
 
-            swarm.behaviour_mut().perf(
-                server_peer_id,
-                client_opts.upload_bytes as u64,
-                client_opts.download_bytes as u64,
-            )?;
+                match event {
+                    Some(SwarmEvent::ConnectionEstablished { peer_id, .. }) => {
+                        swarm.behaviour_mut().perf(
+                            peer_id,
+                            client_opts.upload_bytes as u64,
+                            client_opts.download_bytes as u64,
+                        )?;
+                        println!("done");
+                        break;
+                    }
+                    _ => {}
+                }
+            }
 
             loop {
                 let event = swarm.next().await;

--- a/libp2p/src/main.rs
+++ b/libp2p/src/main.rs
@@ -1,6 +1,5 @@
 use clap::Parser as ClapParser;
 use futures::StreamExt;
-use libp2p::PeerId;
 use libp2p_swarm::SwarmEvent;
 use rand::thread_rng;
 use libp2p::multiaddr::{Multiaddr, Protocol};
@@ -55,25 +54,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     unimplemented!("WebSocket transport layer not implemented yet");
                 }
                 utils::TransportLayer::WebRTC => {
-
                     let address_webrtc = Multiaddr::from(Ipv4Addr::UNSPECIFIED)
                         .with(Protocol::Udp(0))
                         .with(Protocol::WebRTCDirect);
 
-                    println!("Using WebRTC transport layer with address: {}", address_webrtc);
-
+                    tracing::info!("Using WebRTC transport layer with address: {}", address_webrtc);
 
                     libp2p::SwarmBuilder::with_existing_identity(local_key)
                         .with_tokio()
                         .with_other_transport(|key| {
-                            // libp2p_webrtc::tokio::Transport::new(key.clone(), Certificate::generate(&mut thread_rng()).unwrap())
                             Ok(libp2p_webrtc::tokio::Transport::new(
                                 key.clone(),
                                 libp2p_webrtc::tokio::Certificate::generate(&mut thread_rng())?,
                             )
                             .map(|(peer_id, conn), _| (peer_id, StreamMuxerBox::new(conn))))
                         })?
-                        // .with_dns()?
+                        .with_dns()?
                         .with_behaviour(|_key| crate::server::behaviour::Behaviour::new())?
                         .with_swarm_config(|cfg| {
                             cfg.with_idle_connection_timeout(std::time::Duration::from_secs(60))
@@ -116,25 +112,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     let mut swarm = libp2p::SwarmBuilder::with_existing_identity(local_key)
                         .with_tokio()
                         .with_other_transport(|key| {
-                            // libp2p_webrtc::tokio::Transport::new(key.clone(), Certificate::generate(&mut thread_rng()).unwrap())
                             Ok(libp2p_webrtc::tokio::Transport::new(
                                 key.clone(),
                                 libp2p_webrtc::tokio::Certificate::generate(&mut thread_rng())?,
                             )
                             .map(|(peer_id, conn), _| (peer_id, StreamMuxerBox::new(conn))))
                         })?
-                        // .with_dns()?
+                        .with_dns()?
                         .with_behaviour(|_key| crate::client::behaviour::Behaviour::new())?
                         .with_swarm_config(|cfg| {
                             cfg.with_idle_connection_timeout(std::time::Duration::from_secs(60))
                         })
                         .build();
                     
-                    let listen_addr = "/ip4/0.0.0.0/udp/0/webrtc-direct".parse()?;
+                    let listen_addr = Multiaddr::from(Ipv4Addr::UNSPECIFIED)
+                        .with(Protocol::Udp(0))
+                        .with(Protocol::WebRTCDirect);
                     swarm.listen_on(listen_addr)?;
 
                     swarm
-
                 }
             };
 
@@ -144,7 +140,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             loop {
                 let event = swarm.next().await;
                 tracing::info!("Event: {:?}", event);
-
                 match event {
                     Some(SwarmEvent::ConnectionEstablished { peer_id, .. }) => {
                         swarm.behaviour_mut().perf(
@@ -152,18 +147,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             client_opts.upload_bytes as u64,
                             client_opts.download_bytes as u64,
                         )?;
-                        println!("done");
-                        break;
-                    }
-                    _ => {}
-                }
-            }
-
-            loop {
-                let event = swarm.next().await;
-                tracing::info!("Even: {:?}", event);
-
-                match event {
+                    },
                     Some(SwarmEvent::Behaviour(..)) => {
                         return Ok(());
                     }

--- a/libp2p/src/main.rs
+++ b/libp2p/src/main.rs
@@ -17,6 +17,7 @@ mod perf;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_ansi(false)
         .init();
 
     let command = Command::parse();

--- a/libp2p/src/main.rs
+++ b/libp2p/src/main.rs
@@ -1,9 +1,9 @@
 use clap::Parser as ClapParser;
 use futures::StreamExt;
+use libp2p::core::{Transport, muxing::StreamMuxerBox};
+use libp2p::multiaddr::{Multiaddr, Protocol};
 use libp2p_swarm::SwarmEvent;
 use rand::thread_rng;
-use libp2p::multiaddr::{Multiaddr, Protocol};
-use libp2p::core::{muxing::StreamMuxerBox, Transport};
 use std::net::Ipv4Addr;
 
 use utils::Command;
@@ -58,7 +58,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         .with(Protocol::Udp(0))
                         .with(Protocol::WebRTCDirect);
 
-                    tracing::info!("Using WebRTC transport layer with address: {}", address_webrtc);
+                    tracing::info!(
+                        "Using WebRTC transport layer with address: {}",
+                        address_webrtc
+                    );
 
                     libp2p::SwarmBuilder::with_existing_identity(local_key)
                         .with_tokio()
@@ -124,7 +127,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             cfg.with_idle_connection_timeout(std::time::Duration::from_secs(60))
                         })
                         .build();
-                    
+
                     let listen_addr = Multiaddr::from(Ipv4Addr::UNSPECIFIED)
                         .with(Protocol::Udp(0))
                         .with(Protocol::WebRTCDirect);
@@ -147,7 +150,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             client_opts.upload_bytes as u64,
                             client_opts.download_bytes as u64,
                         )?;
-                    },
+                    }
                     Some(SwarmEvent::Behaviour(..)) => {
                         return Ok(());
                     }

--- a/libp2p/src/perf.rs
+++ b/libp2p/src/perf.rs
@@ -51,15 +51,36 @@ async fn send_bytes<S: AsyncRead + AsyncWrite + Unpin + Send + 'static>(
 pub async fn server_mode<S: AsyncRead + AsyncWrite + Unpin + Send + 'static>(
     mut substream: S,
 ) -> Result<(), std::io::Error> {
+    tracing::info!(target: LOG_TARGET, "Server mode started");
     // Step 1. Read the download bytes.
     let to_recv = read_u64(&mut substream).await?;
+    tracing::info!(
+        target: LOG_TARGET,
+        "Read download bytes: {}",
+        utils::format_bytes(to_recv as usize)
+    );
     // Step 2. Receive the download bytes.
     recv_bytes(&mut substream, to_recv).await?;
+    tracing::info!(
+        target: LOG_TARGET,
+        "Received download bytes: {}",
+        utils::format_bytes(to_recv as usize)
+    );
 
     // Step 3. Read the upload bytes.
     let to_send = read_u64(&mut substream).await?;
+    tracing::info!(
+        target: LOG_TARGET,
+        "Read upload bytes: {}",
+        utils::format_bytes(to_send as usize)
+    );
     // Step 4. Send the upload bytes.
     send_bytes(&mut substream, to_send).await?;
+    tracing::info!(
+        target: LOG_TARGET,
+        "Sent upload bytes: {}",
+        utils::format_bytes(to_send as usize)
+    );
 
     Ok(())
 }
@@ -84,6 +105,11 @@ pub async fn client_mode<S: AsyncRead + AsyncWrite + Unpin + Send + 'static>(
     );
     // Step 3. Send the download bytes.
     write_u64(&mut substream, download_bytes).await?;
+    tracing::info!(
+        target: LOG_TARGET,
+        "Sent download bytes: {}",
+        utils::format_bytes(download_bytes as usize)
+    );
     // Step 4. Receive the download bytes.
     let now = std::time::Instant::now();
     recv_bytes(&mut substream, download_bytes).await?;

--- a/libp2p/src/perf.rs
+++ b/libp2p/src/perf.rs
@@ -16,6 +16,7 @@ async fn write_u64<S: AsyncRead + AsyncWrite + Unpin + Send + 'static>(
     value: u64,
 ) -> Result<(), std::io::Error> {
     substream.write_all(&value.to_be_bytes()).await?;
+    substream.flush().await?;
     Ok(())
 }
 
@@ -43,6 +44,7 @@ async fn send_bytes<S: AsyncRead + AsyncWrite + Unpin + Send + 'static>(
     let mut total = 0;
     while total < to_send {
         substream.write_all(&buf).await?;
+        substream.flush().await?;
         total += buf.len() as u64;
     }
     Ok(())

--- a/libp2p/src/perf.rs
+++ b/libp2p/src/perf.rs
@@ -53,36 +53,15 @@ async fn send_bytes<S: AsyncRead + AsyncWrite + Unpin + Send + 'static>(
 pub async fn server_mode<S: AsyncRead + AsyncWrite + Unpin + Send + 'static>(
     mut substream: S,
 ) -> Result<(), std::io::Error> {
-    tracing::info!(target: LOG_TARGET, "Server mode started");
     // Step 1. Read the download bytes.
     let to_recv = read_u64(&mut substream).await?;
-    tracing::info!(
-        target: LOG_TARGET,
-        "Read download bytes: {}",
-        utils::format_bytes(to_recv as usize)
-    );
     // Step 2. Receive the download bytes.
     recv_bytes(&mut substream, to_recv).await?;
-    tracing::info!(
-        target: LOG_TARGET,
-        "Received download bytes: {}",
-        utils::format_bytes(to_recv as usize)
-    );
 
     // Step 3. Read the upload bytes.
     let to_send = read_u64(&mut substream).await?;
-    tracing::info!(
-        target: LOG_TARGET,
-        "Read upload bytes: {}",
-        utils::format_bytes(to_send as usize)
-    );
     // Step 4. Send the upload bytes.
     send_bytes(&mut substream, to_send).await?;
-    tracing::info!(
-        target: LOG_TARGET,
-        "Sent upload bytes: {}",
-        utils::format_bytes(to_send as usize)
-    );
 
     Ok(())
 }
@@ -107,11 +86,6 @@ pub async fn client_mode<S: AsyncRead + AsyncWrite + Unpin + Send + 'static>(
     );
     // Step 3. Send the download bytes.
     write_u64(&mut substream, download_bytes).await?;
-    tracing::info!(
-        target: LOG_TARGET,
-        "Sent download bytes: {}",
-        utils::format_bytes(download_bytes as usize)
-    );
     // Step 4. Receive the download bytes.
     let now = std::time::Instant::now();
     recv_bytes(&mut substream, download_bytes).await?;

--- a/libp2p/src/server/behaviour.rs
+++ b/libp2p/src/server/behaviour.rs
@@ -63,7 +63,7 @@ impl NetworkBehaviour for Behaviour {
             .push_back(ToSwarm::GenerateEvent(Event {}))
     }
 
-    #[tracing::instrument(level = "trace", name = "NetworkBehaviour::poll", skip(self))]
+    #[tracing::instrument(level = "info", name = "NetworkBehaviour::poll", skip(self))]
     fn poll(&mut self, _: &mut Context<'_>) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
         if let Some(event) = self.queued_events.pop_front() {
             return Poll::Ready(event);

--- a/libp2p/src/server/behaviour.rs
+++ b/libp2p/src/server/behaviour.rs
@@ -63,7 +63,7 @@ impl NetworkBehaviour for Behaviour {
             .push_back(ToSwarm::GenerateEvent(Event {}))
     }
 
-    #[tracing::instrument(level = "info", name = "NetworkBehaviour::poll", skip(self))]
+    #[tracing::instrument(level = "trace", name = "NetworkBehaviour::poll", skip(self))]
     fn poll(&mut self, _: &mut Context<'_>) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
         if let Some(event) = self.queued_events.pop_front() {
             return Poll::Ready(event);

--- a/libp2p/src/server/handler.rs
+++ b/libp2p/src/server/handler.rs
@@ -60,6 +60,11 @@ impl ConnectionHandler for Handler {
             Self::OutboundOpenInfo,
         >,
     ) {
+        tracing::info!(
+            target: "Handler",
+            "Handling connection event: {:?}",
+            event
+        );
         match event {
             ConnectionEvent::FullyNegotiatedInbound(FullyNegotiatedInbound {
                 protocol,
@@ -85,7 +90,8 @@ impl ConnectionHandler for Handler {
             // TODO: remove when Rust 1.82 is MSRV
             #[allow(unreachable_patterns)]
             ConnectionEvent::ListenUpgradeError(ListenUpgradeError { info: (), error }) => {
-                void::unreachable(error)
+                // void::unreachable(error)
+                panic!("ListenUpgradeError should not occur in this context: {:?}", error);
             }
             _ => {}
         }

--- a/libp2p/src/server/handler.rs
+++ b/libp2p/src/server/handler.rs
@@ -60,11 +60,6 @@ impl ConnectionHandler for Handler {
             Self::OutboundOpenInfo,
         >,
     ) {
-        tracing::info!(
-            target: "Handler",
-            "Handling connection event: {:?}",
-            event
-        );
         match event {
             ConnectionEvent::FullyNegotiatedInbound(FullyNegotiatedInbound {
                 protocol,
@@ -90,7 +85,6 @@ impl ConnectionHandler for Handler {
             // TODO: remove when Rust 1.82 is MSRV
             #[allow(unreachable_patterns)]
             ConnectionEvent::ListenUpgradeError(ListenUpgradeError { info: (), error }) => {
-                // void::unreachable(error)
                 panic!("ListenUpgradeError should not occur in this context: {:?}", error);
             }
             _ => {}

--- a/libp2p/src/server/handler.rs
+++ b/libp2p/src/server/handler.rs
@@ -85,7 +85,10 @@ impl ConnectionHandler for Handler {
             // TODO: remove when Rust 1.82 is MSRV
             #[allow(unreachable_patterns)]
             ConnectionEvent::ListenUpgradeError(ListenUpgradeError { info: (), error }) => {
-                panic!("ListenUpgradeError should not occur in this context: {:?}", error);
+                panic!(
+                    "ListenUpgradeError should not occur in this context: {:?}",
+                    error
+                );
             }
             _ => {}
         }

--- a/litep2p/Cargo.toml
+++ b/litep2p/Cargo.toml
@@ -11,6 +11,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing = "0.1.34"
 futures = "0.3.28"
 
-litep2p = { version = "0.10.0", features = ["websocket", "webrtc"] }
+litep2p = { git = "https://github.com/timwu20/litep2p", rev = "9fb09abd77f88450f673c40e51b57aa0c7f4d358", features = ["websocket", "webrtc"] }
 
 utils = { path = "../utils" }

--- a/litep2p/Cargo.toml
+++ b/litep2p/Cargo.toml
@@ -11,6 +11,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing = "0.1.34"
 futures = "0.3.28"
 
-litep2p = { git = "https://github.com/timwu20/litep2p", rev = "9fb09abd77f88450f673c40e51b57aa0c7f4d358", features = ["websocket", "webrtc"] }
+litep2p = { git = "https://github.com/ChainSafe/litep2p", rev = "9621e3ccda915882f0dc93b7c2ea46c80c0fea7a", features = ["websocket", "webrtc"] }
 
 utils = { path = "../utils" }

--- a/litep2p/Cargo.toml
+++ b/litep2p/Cargo.toml
@@ -11,6 +11,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing = "0.1.34"
 futures = "0.3.28"
 
-litep2p = { git = "https://github.com/ChainSafe/litep2p", rev = "9621e3ccda915882f0dc93b7c2ea46c80c0fea7a", features = ["websocket", "webrtc"] }
+litep2p = { git = "https://github.com/ChainSafe/litep2p", rev = "78d0b6da78aaf9bae8af1f58d427bdd139f36521", features = ["websocket", "webrtc"] }
 
 utils = { path = "../utils" }

--- a/litep2p/Cargo.toml
+++ b/litep2p/Cargo.toml
@@ -11,6 +11,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing = "0.1.34"
 futures = "0.3.28"
 
-litep2p = { git = "https://github.com/ChainSafe/litep2p", rev = "78d0b6da78aaf9bae8af1f58d427bdd139f36521", features = ["websocket", "webrtc"] }
+litep2p = { git = "https://github.com/paritytech/litep2p", branch = "master", features = ["websocket", "webrtc"] }
 
 utils = { path = "../utils" }

--- a/litep2p/src/main.rs
+++ b/litep2p/src/main.rs
@@ -27,9 +27,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let secret_key = litep2p::crypto::ed25519::SecretKey::try_from_bytes(&mut bytes)?;
             let mut litep2p_config = litep2p::config::ConfigBuilder::new()
                 .with_keypair(secret_key.into())
-                // After the keep alive timeout elapsed while no new substreams have been opened on
-                // the connection, litep2p downgrades it to inactive.
-                .with_keep_alive_timeout(Duration::from_mins(5))
                 .with_user_protocol(Box::new(perf));
 
             match server_opts.transport_layer {

--- a/litep2p/src/main.rs
+++ b/litep2p/src/main.rs
@@ -1,3 +1,4 @@
+use std::time::Duration;
 use clap::Parser as ClapParser;
 
 use utils::Command;
@@ -26,6 +27,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let secret_key = litep2p::crypto::ed25519::SecretKey::try_from_bytes(&mut bytes)?;
             let mut litep2p_config = litep2p::config::ConfigBuilder::new()
                 .with_keypair(secret_key.into())
+                // After the keep alive timeout elapsed while no new substreams have been opened on
+                // the connection, litep2p downgrades it to inactive.
+                .with_keep_alive_timeout(Duration::from_mins(5))
                 .with_user_protocol(Box::new(perf));
 
             match server_opts.transport_layer {

--- a/litep2p/src/main.rs
+++ b/litep2p/src/main.rs
@@ -1,4 +1,3 @@
-use std::time::Duration;
 use clap::Parser as ClapParser;
 
 use utils::Command;

--- a/litep2p/src/main.rs
+++ b/litep2p/src/main.rs
@@ -8,6 +8,7 @@ mod perf;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_ansi(false)
         .init();
 
     let command = Command::parse();

--- a/run_bandwidth.sh
+++ b/run_bandwidth.sh
@@ -1,5 +1,4 @@
-#!/opt/homebrew/bin/bash
-##!/bin/bash
+#!/usr/bin/env bash
 
 declare -A results_upload_smoldot_litep2p_webrtc
 declare -A results_download_smoldot_litep2p_webrtc

--- a/run_bandwidth.sh
+++ b/run_bandwidth.sh
@@ -234,7 +234,6 @@ for bytes in $VALUES; do
 
     downloaded_bandwidth=$(echo "$result_line" | cut -d' ' -f8-9 | tail -n 1)
     results_download_litep2p_libp2p_tcp[$bytes]="$downloaded_bandwidth"
-
 done
 
 # Kill the server
@@ -256,8 +255,6 @@ echo "Running bandwidth test smoldot -> litep2p (WebRTC). Server pid $SERVER_PID
 sleep $((SLEEP_TIME * 5))
 
 CERT_HASH=$(grep "/certhash/" server.log | cut -d '/' -f 8 | cut -d ' ' -f 1 | head -n 1)
-
-VALUES_ARRAY=($VALUES)
 cd ..
 
 for bytes in $VALUES; do
@@ -265,9 +262,15 @@ for bytes in $VALUES; do
     echo $OUTPUT
 
     uploaded_bandwidth=$(echo "$OUTPUT" | cut -d' ' -f8-9 | head -n 1)
+    if [ -z "$uploaded_bandwidth" ]; then
+        uploaded_bandwidth="fail"
+    fi
     results_upload_smoldot_litep2p_webrtc[$bytes]="$uploaded_bandwidth"
 
     downloaded_bandwidth=$(echo "$OUTPUT" | cut -d' ' -f8-9 | tail -n 1)
+    if [ -z "$downloaded_bandwidth" ]; then
+        downloaded_bandwidth="fail"
+    fi
     results_download_smoldot_litep2p_webrtc[$bytes]="$downloaded_bandwidth"
 done
 

--- a/run_bandwidth.sh
+++ b/run_bandwidth.sh
@@ -1,4 +1,8 @@
-#!/bin/bash
+#!/opt/homebrew/bin/bash
+##!/bin/bash
+
+declare -A results_upload_smoldot_litep2p_webrtc
+declare -A results_download_smoldot_litep2p_webrtc
 
 declare -A results_upload_litep2p_litep2p_tcp
 declare -A results_download_litep2p_litep2p_tcp
@@ -236,19 +240,54 @@ done
 # Kill the server
 kill $SERVER_PID
 
+# ---------------------------------------------------------
+# Smoldot -> Litep2p (WebRTC)
+# ---------------------------------------------------------
+
+cd ../litep2p
+# Start the server
+RUST_LOG=info cargo run -- server --transport-layer "webrtc" --listen-address "/ip4/127.0.0.1/udp/8888/webrtc-direct" --node-key "secret" > server.log 2>&1 &
+
+# Get the PID of the server
+SERVER_PID=$!
+
+echo "Running bandwidth test smoldot -> litep2p (WebRTC). Server pid $SERVER_PID..."
+# Wait for the server to start listening on the address.
+sleep $((SLEEP_TIME * 5))
+
+CERT_HASH=$(grep "/certhash/" server.log | cut -d '/' -f 8 | cut -d ' ' -f 1 | head -n 1)
+
+VALUES_ARRAY=($VALUES)
+cd ..
+
+for bytes in $VALUES; do
+    OUTPUT=$(cargo run --bin "smoldot-automation" -p smoldot-automation -- "/ip4/127.0.0.1/udp/8888/webrtc-direct/certhash/${CERT_HASH}/p2p/12D3KooWBpZHDZu7YSbvPaPXKhkRNJvR7MkTJMQQAVBKx9mCqz3q" $bytes $bytes | grep bandwidth)
+    echo $OUTPUT
+
+    uploaded_bandwidth=$(echo "$OUTPUT" | cut -d' ' -f8-9 | head -n 1)
+    results_upload_smoldot_litep2p_webrtc[$bytes]="$uploaded_bandwidth"
+
+    downloaded_bandwidth=$(echo "$OUTPUT" | cut -d' ' -f8-9 | tail -n 1)
+    results_download_smoldot_litep2p_webrtc[$bytes]="$downloaded_bandwidth"
+done
+
+# Kill the server
+kill $SERVER_PID
+rm litep2p/server.log
+
 # Markdown output
 echo
 echo "# Bandwidth Report"
-echo "| Operation  | Bytes      | Litep2p->Litep2p (TCP) | Libp2p->Libp2p (TCP) | Libp2p->Libp2p (WebRTC) | Libp2p->Litep2p (TCP) | Libp2p->Litep2p (WebRTC) | Litep2p->Libp2p (TCP) |"
-echo "|------------|------------|------------------------|----------------------|-------------------------|-----------------------|--------------------------|-----------------------|"
+echo "| Operation  | Bytes      | Litep2p->Litep2p (TCP) | Libp2p->Libp2p (TCP) | Libp2p->Libp2p (WebRTC) | Libp2p->Litep2p (TCP) | Libp2p->Litep2p (WebRTC) | Litep2p->Libp2p (TCP) | Smoldot -> Litep2p (WebRTC) |"
+echo "|------------|------------|------------------------|----------------------|-------------------------|-----------------------|--------------------------|-----------------------|-----------------------------|"
 
 for bytes in $VALUES; do
     fmt_bytes=$(numfmt --to=iec-i --suffix=B $bytes)
-    echo "| Uploaded   | $fmt_bytes | ${results_upload_litep2p_litep2p_tcp[$bytes]} | ${results_upload_libp2p_libp2p_tcp[$bytes]} | ${results_upload_libp2p_libp2p_webrtc[$bytes]} | ${results_upload_libp2p_litep2p_tcp[$bytes]} | ${results_upload_libp2p_litep2p_webrtc[$bytes]} | ${results_upload_litep2p_libp2p_tcp[$bytes]} |"
+    echo "| Uploaded   | $fmt_bytes | ${results_upload_litep2p_litep2p_tcp[$bytes]} | ${results_upload_libp2p_libp2p_tcp[$bytes]} | ${results_upload_libp2p_libp2p_webrtc[$bytes]} | ${results_upload_libp2p_litep2p_tcp[$bytes]} | ${results_upload_libp2p_litep2p_webrtc[$bytes]} | ${results_upload_litep2p_libp2p_tcp[$bytes]} | ${results_upload_smoldot_litep2p_webrtc[$bytes]} |"
 done
 
 
 for bytes in $VALUES; do
     fmt_bytes=$(numfmt --to=iec-i --suffix=B $bytes)
-    echo "| Downloaded | $fmt_bytes | ${results_download_litep2p_litep2p_tcp[$bytes]} | ${results_download_libp2p_libp2p_tcp[$bytes]} | ${results_download_libp2p_libp2p_webrtc[$bytes]} | ${results_download_libp2p_litep2p_tcp[$bytes]} | ${results_download_libp2p_litep2p_webrtc[$bytes]} | ${results_download_litep2p_libp2p_tcp[$bytes]} |"
+    echo "| Downloaded | $fmt_bytes | ${results_download_litep2p_litep2p_tcp[$bytes]} | ${results_download_libp2p_libp2p_tcp[$bytes]} | ${results_download_libp2p_libp2p_webrtc[$bytes]} | ${results_download_libp2p_litep2p_tcp[$bytes]} | ${results_download_libp2p_litep2p_webrtc[$bytes]} | ${results_download_litep2p_libp2p_tcp[$bytes]} | ${results_download_smoldot_litep2p_webrtc[$bytes]} |"
 done

--- a/run_bandwidth.sh
+++ b/run_bandwidth.sh
@@ -21,7 +21,7 @@ declare -A results_download_libp2p_litep2p_webrtc
 declare -A results_upload_litep2p_libp2p_tcp
 declare -A results_download_litep2p_libp2p_tcp
 
-SLEEP_TIME=1
+SLEEP_TIME=5
 
 #         0    1    2    3    4     5     6      7      8      9       10     11      12      13       14      15        16       17        18        19         20
 VALUES="1024 2048 4096 8192 16384 32768 65536 131072 262144 524288 1048576 2097152 4194304 8388608 16777216 33554432 67108864 134217728 268435456 536870912 1073741824"
@@ -108,7 +108,7 @@ SERVER_PID=$!
 echo "Running bandwidth test with libp2p (WebRTC). Server pid $SERVER_PID..."
 
 # Wait for the server to start listening on the address.
-sleep $((SLEEP_TIME * 5))
+sleep $SLEEP_TIME
 
 CERT_HASH=$(grep "/certhash/" server.log | cut -d '/' -f 8 | cut -d ' ' -f 1 | head -n 1)
 
@@ -176,7 +176,7 @@ SERVER_PID=$!
 
 echo "Running bandwidth test libp2p -> litep2p (WebRTC). Server pid $SERVER_PID..."
 # Wait for the server to start listening on the address.
-sleep $((SLEEP_TIME * 5))
+sleep $SLEEP_TIME
 
 CERT_HASH=$(grep "/certhash/" server.log | cut -d '/' -f 8 | cut -d ' ' -f 1 | head -n 1)
 
@@ -251,7 +251,7 @@ SERVER_PID=$!
 
 echo "Running bandwidth test smoldot -> litep2p (WebRTC). Server pid $SERVER_PID..."
 # Wait for the server to start listening on the address.
-sleep $((SLEEP_TIME * 5))
+sleep $SLEEP_TIME
 
 CERT_HASH=$(grep "/certhash/" server.log | cut -d '/' -f 8 | cut -d ' ' -f 1 | head -n 1)
 cd ..

--- a/run_bandwidth.sh
+++ b/run_bandwidth.sh
@@ -1,19 +1,26 @@
 #!/bin/bash
 
-declare -A results_upload_litep2p_litep2p
-declare -A results_download_litep2p_litep2p
+declare -A results_upload_litep2p_litep2p_tcp
+declare -A results_download_litep2p_litep2p_tcp
 
-declare -A results_upload_libp2p_libp2p
-declare -A results_download_libp2p_libp2p
+declare -A results_upload_libp2p_libp2p_tcp
+declare -A results_download_libp2p_libp2p_tcp
 
-declare -A results_upload_libp2p_litep2p
-declare -A results_download_libp2p_litep2p
+declare -A results_upload_libp2p_libp2p_webrtc
+declare -A results_download_libp2p_libp2p_webrtc
 
-declare -A results_upload_litep2p_libp2p
-declare -A results_download_litep2p_libp2p
+declare -A results_upload_libp2p_litep2p_tcp
+declare -A results_download_libp2p_litep2p_tcp
+
+declare -A results_upload_libp2p_litep2p_webrtc
+declare -A results_download_libp2p_litep2p_webrtc
+
+declare -A results_upload_litep2p_libp2p_tcp
+declare -A results_download_litep2p_libp2p_tcp
 
 SLEEP_TIME=1
 
+#         0    1    2    3    4     5     6      7      8      9       10     11      12      13       14      15        16       17        18        19         20
 VALUES="1024 2048 4096 8192 16384 32768 65536 131072 262144 524288 1048576 2097152 4194304 8388608 16777216 33554432 67108864 134217728 268435456 536870912 1073741824"
 
 # ---------------------------------------------------------
@@ -28,7 +35,7 @@ RUST_LOG=info cargo run -- server --listen-address "/ip6/::/tcp/33333" --node-ke
 # Get the PID of the server
 SERVER_PID=$!
 
-echo "Running bandwidth test with litep2p. Server pid $SERVER_PID..."
+echo "Running bandwidth test with litep2p (TCP). Server pid $SERVER_PID..."
 # Wait for the server to start listening on the address.
 sleep $SLEEP_TIME
 
@@ -40,17 +47,17 @@ for bytes in $VALUES; do
     echo $result_line
 
     uploaded_bandwidth=$(echo "$result_line" | cut -d' ' -f8-9 | head -n 1)
-    results_upload_litep2p_litep2p[$bytes]="$uploaded_bandwidth"
+    results_upload_litep2p_litep2p_tcp[$bytes]="$uploaded_bandwidth"
 
     downloaded_bandwidth=$(echo "$result_line" | cut -d' ' -f8-9 | tail -n 1)
-    results_download_litep2p_litep2p[$bytes]="$downloaded_bandwidth"
+    results_download_litep2p_litep2p_tcp[$bytes]="$downloaded_bandwidth"
 done
 
 # Kill the server
 kill $SERVER_PID
 
 # ---------------------------------------------------------
-# Libp2p bandwidth test
+# Libp2p (TCP) bandwidth test
 # ---------------------------------------------------------
 
 cd ../libp2p
@@ -61,7 +68,7 @@ RUST_LOG=info cargo run -- server --listen-address "/ip6/::/tcp/33333" --node-ke
 # Get the PID of the server
 SERVER_PID=$!
 
-echo "Running bandwidth test with libp2p. Server pid $SERVER_PID..."
+echo "Running bandwidth test with libp2p (TCP). Server pid $SERVER_PID..."
 
 # Wait for the server to start listening on the address.
 sleep $SLEEP_TIME
@@ -74,10 +81,10 @@ for bytes in $VALUES; do
     echo $result_line
 
     uploaded_bandwidth=$(echo "$result_line" | cut -d' ' -f8-9 | head -n 1)
-    results_upload_libp2p_libp2p[$bytes]="$uploaded_bandwidth"
+    results_upload_libp2p_libp2p_tcp[$bytes]="$uploaded_bandwidth"
 
     downloaded_bandwidth=$(echo "$result_line" | cut -d' ' -f8-9 | tail -n 1)
-    results_download_libp2p_libp2p[$bytes]="$downloaded_bandwidth"
+    results_download_libp2p_libp2p_tcp[$bytes]="$downloaded_bandwidth"
 done
 
 # Kill the server
@@ -85,7 +92,44 @@ kill $SERVER_PID
 
 
 # ---------------------------------------------------------
-# Libp2p -> Litep2p
+# Libp2p (WebRTC) bandwidth test
+# ---------------------------------------------------------
+
+cd ../libp2p
+
+# Start the server
+RUST_LOG=info cargo run -- server --transport-layer "webrtc" --listen-address "/ip4/127.0.0.1/udp/8888/webrtc-direct" --node-key "secret" > server.log 2>&1 &
+
+# Get the PID of the server
+SERVER_PID=$!
+
+echo "Running bandwidth test with libp2p (WebRTC). Server pid $SERVER_PID..."
+
+# Wait for the server to start listening on the address.
+sleep $((SLEEP_TIME * 5))
+
+CERT_HASH=$(grep "/certhash/" server.log | cut -d '/' -f 8 | cut -d ' ' -f 1 | head -n 1)
+
+cd ../libp2p
+for bytes in $VALUES; do
+    OUTPUT=$(RUST_LOG=info cargo run -- client --transport-layer "webrtc" --server-address "/ip4/127.0.0.1/udp/8888/webrtc-direct/certhash/${CERT_HASH}/p2p/12D3KooWBpZHDZu7YSbvPaPXKhkRNJvR7MkTJMQQAVBKx9mCqz3q" --upload-bytes $bytes --download-bytes $bytes | grep bandwidth)
+
+    result_line=$(echo "$OUTPUT" | cut -d ' ' -f5-13)
+    echo $result_line
+
+    uploaded_bandwidth=$(echo "$result_line" | cut -d' ' -f8-9 | head -n 1)
+    results_upload_libp2p_libp2p_webrtc[$bytes]="$uploaded_bandwidth"
+
+    downloaded_bandwidth=$(echo "$result_line" | cut -d' ' -f8-9 | tail -n 1)
+    results_download_libp2p_libp2p_webrtc[$bytes]="$downloaded_bandwidth"
+done
+
+# Kill the server
+kill $SERVER_PID
+rm ../libp2p/server.log
+
+# ---------------------------------------------------------
+# Libp2p -> Litep2p (TCP)
 # ---------------------------------------------------------
 
 cd ../litep2p
@@ -95,7 +139,7 @@ RUST_LOG=info cargo run -- server --listen-address "/ip6/::/tcp/33333" --node-ke
 # Get the PID of the server
 SERVER_PID=$!
 
-echo "Running bandwidth test libp2p -> litep2p. Server pid $SERVER_PID..."
+echo "Running bandwidth test libp2p -> litep2p (TCP). Server pid $SERVER_PID..."
 # Wait for the server to start listening on the address.
 sleep $SLEEP_TIME
 
@@ -107,10 +151,10 @@ for bytes in $VALUES; do
     echo $result_line
 
     uploaded_bandwidth=$(echo "$result_line" | cut -d' ' -f8-9 | head -n 1)
-    results_upload_libp2p_litep2p[$bytes]="$uploaded_bandwidth"
+    results_upload_libp2p_litep2p_tcp[$bytes]="$uploaded_bandwidth"
 
     downloaded_bandwidth=$(echo "$result_line" | cut -d' ' -f8-9 | tail -n 1)
-    results_download_libp2p_litep2p[$bytes]="$downloaded_bandwidth"
+    results_download_libp2p_litep2p_tcp[$bytes]="$downloaded_bandwidth"
 
 done
 
@@ -118,7 +162,63 @@ done
 kill $SERVER_PID
 
 # ---------------------------------------------------------
-# Litep2p -> Libp2p
+# Libp2p -> Litep2p (WebRTC)
+# ---------------------------------------------------------
+
+cd ../litep2p
+# Start the server
+RUST_LOG=info cargo run -- server --transport-layer "webrtc" --listen-address "/ip4/127.0.0.1/udp/8888/webrtc-direct" --node-key "secret" > server.log 2>&1 &
+
+# Get the PID of the server
+SERVER_PID=$!
+
+echo "Running bandwidth test libp2p -> litep2p (WebRTC). Server pid $SERVER_PID..."
+# Wait for the server to start listening on the address.
+sleep $((SLEEP_TIME * 5))
+
+CERT_HASH=$(grep "/certhash/" server.log | cut -d '/' -f 8 | cut -d ' ' -f 1 | head -n 1)
+
+VALUES_ARRAY=($VALUES)
+
+cd ../libp2p
+# Only do both up- and download up to 512kB because downloading from litep2p to libp2p is too damn slow. :(
+for bytes in "${VALUES_ARRAY[@]:0:10}"; do
+    OUTPUT=$(RUST_LOG=info cargo run -- client --transport-layer "webrtc" --server-address "/ip4/127.0.0.1/udp/8888/webrtc-direct/certhash/${CERT_HASH}/p2p/12D3KooWBpZHDZu7YSbvPaPXKhkRNJvR7MkTJMQQAVBKx9mCqz3q" --upload-bytes $bytes --download-bytes $bytes | grep bandwidth)
+
+    result_line=$(echo "$OUTPUT" | cut -d ' ' -f5-13)
+    echo $result_line
+
+    uploaded_bandwidth=$(echo "$result_line" | cut -d' ' -f8-9 | head -n 1)
+    results_upload_libp2p_litep2p_webrtc[$bytes]="$uploaded_bandwidth"
+
+    downloaded_bandwidth=$(echo "$result_line" | cut -d' ' -f8-9 | tail -n 1)
+    results_download_libp2p_litep2p_webrtc[$bytes]="$downloaded_bandwidth"
+done
+
+# Do upload from libp2p to litep2p up to 16MB because the connection breaks after that.
+for bytes in "${VALUES_ARRAY[@]:10:5}"; do
+    OUTPUT=$(RUST_LOG=info cargo run -- client --transport-layer "webrtc" --server-address "/ip4/127.0.0.1/udp/8888/webrtc-direct/certhash/${CERT_HASH}/p2p/12D3KooWBpZHDZu7YSbvPaPXKhkRNJvR7MkTJMQQAVBKx9mCqz3q" --upload-bytes $bytes --download-bytes 1024 | grep bandwidth)
+
+    result_line=$(echo "$OUTPUT" | cut -d ' ' -f5-13)
+    echo $result_line
+
+    uploaded_bandwidth=$(echo "$result_line" | cut -d' ' -f8-9 | head -n 1)
+    results_upload_libp2p_litep2p_webrtc[$bytes]="$uploaded_bandwidth"
+
+    results_download_libp2p_litep2p_webrtc[$bytes]="n/a"
+done
+
+for bytes in "${VALUES_ARRAY[@]:15}"; do
+    results_upload_libp2p_litep2p_webrtc[$bytes]="n/a"
+    results_download_libp2p_litep2p_webrtc[$bytes]="n/a"
+done
+
+# Kill the server
+kill $SERVER_PID
+rm ../litep2p/server.log
+
+# ---------------------------------------------------------
+# Litep2p -> Libp2p (TCP)
 # ---------------------------------------------------------
 
 cd ../libp2p
@@ -128,7 +228,7 @@ RUST_LOG=info cargo run -- server --listen-address "/ip6/::/tcp/33333" --node-ke
 # Get the PID of the server
 SERVER_PID=$!
 
-echo "Running bandwidth test libp2p -> litep2p. Server pid $SERVER_PID..."
+echo "Running bandwidth test litep2p -> libp2p (TCP). Server pid $SERVER_PID..."
 # Wait for the server to start listening on the address.
 sleep $SLEEP_TIME
 
@@ -140,30 +240,30 @@ for bytes in $VALUES; do
     echo $result_line
 
     uploaded_bandwidth=$(echo "$result_line" | cut -d' ' -f8-9 | head -n 1)
-    results_upload_litep2p_libp2p[$bytes]="$uploaded_bandwidth"
+    results_upload_litep2p_libp2p_tcp[$bytes]="$uploaded_bandwidth"
 
     downloaded_bandwidth=$(echo "$result_line" | cut -d' ' -f8-9 | tail -n 1)
-    results_download_litep2p_libp2p[$bytes]="$downloaded_bandwidth"
+    results_download_litep2p_libp2p_tcp[$bytes]="$downloaded_bandwidth"
 
 done
 
 # Kill the server
 kill $SERVER_PID
-
 
 # Markdown output
 echo
 echo "# Bandwidth Report"
-echo "| Operation  | Bytes      | Litep2p->Litep2p | Libp2p->Libp2p | Libp2p->Litep2p | Litep2p->Libp2p |"
-echo "|------------|------------|------------------|----------------|-----------------|-----------------|"
+echo "| Operation  | Bytes      | Litep2p->Litep2p | Libp2p->Libp2p | Libp2p->Libp2p | Libp2p->Litep2p | Libp2p->Litep2p | Litep2p->Libp2p |"
+echo "|            |            | (TCP)            | (TCP)          | (WebRTC)       | (TCP)           | (WebRTC)        | (TCP)           |"
+echo "|------------|------------|------------------|----------------|----------------|-----------------|-----------------|-----------------|"
 
 for bytes in $VALUES; do
     fmt_bytes=$(numfmt --to=iec-i --suffix=B $bytes)
-    echo "| Uploaded   | $fmt_bytes | ${results_upload_litep2p_litep2p[$bytes]} | ${results_upload_libp2p_libp2p[$bytes]} | ${results_upload_libp2p_litep2p[$bytes]} | ${results_upload_litep2p_libp2p[$bytes]} |"
+    echo "| Uploaded   | $fmt_bytes | ${results_upload_litep2p_litep2p_tcp[$bytes]} | ${results_upload_libp2p_libp2p_tcp[$bytes]} | ${results_upload_libp2p_libp2p_webrtc[$bytes]} | ${results_upload_libp2p_litep2p_tcp[$bytes]} | ${results_upload_libp2p_litep2p_webrtc[$bytes]} | ${results_upload_litep2p_libp2p_tcp[$bytes]} |"
 done
 
 
 for bytes in $VALUES; do
     fmt_bytes=$(numfmt --to=iec-i --suffix=B $bytes)
-    echo "| Downloaded | $fmt_bytes | ${results_download_litep2p_litep2p[$bytes]} | ${results_download_libp2p_libp2p[$bytes]} | ${results_download_libp2p_litep2p[$bytes]} | ${results_download_litep2p_libp2p[$bytes]} |"
+    echo "| Downloaded | $fmt_bytes | ${results_download_litep2p_litep2p_tcp[$bytes]} | ${results_download_libp2p_libp2p_tcp[$bytes]} | ${results_download_libp2p_libp2p_webrtc[$bytes]} | ${results_download_libp2p_litep2p_tcp[$bytes]} | ${results_download_libp2p_litep2p_webrtc[$bytes]} | ${results_download_litep2p_libp2p_tcp[$bytes]} |"
 done

--- a/run_bandwidth.sh
+++ b/run_bandwidth.sh
@@ -90,7 +90,6 @@ done
 # Kill the server
 kill $SERVER_PID
 
-
 # ---------------------------------------------------------
 # Libp2p (WebRTC) bandwidth test
 # ---------------------------------------------------------
@@ -181,8 +180,9 @@ CERT_HASH=$(grep "/certhash/" server.log | cut -d '/' -f 8 | cut -d ' ' -f 1 | h
 VALUES_ARRAY=($VALUES)
 
 cd ../libp2p
-# Only do both up- and download up to 512kB because downloading from litep2p to libp2p is too damn slow. :(
-for bytes in "${VALUES_ARRAY[@]:0:10}"; do
+# Only do up- and download up to 512MiB. 1GiB still doesn't work reliably.
+for bytes in "${VALUES_ARRAY[@]:0:20}"; do
+#for bytes in $VALUES; do
     OUTPUT=$(RUST_LOG=info cargo run -- client --transport-layer "webrtc" --server-address "/ip4/127.0.0.1/udp/8888/webrtc-direct/certhash/${CERT_HASH}/p2p/12D3KooWBpZHDZu7YSbvPaPXKhkRNJvR7MkTJMQQAVBKx9mCqz3q" --upload-bytes $bytes --download-bytes $bytes | grep bandwidth)
 
     result_line=$(echo "$OUTPUT" | cut -d ' ' -f5-13)
@@ -195,23 +195,9 @@ for bytes in "${VALUES_ARRAY[@]:0:10}"; do
     results_download_libp2p_litep2p_webrtc[$bytes]="$downloaded_bandwidth"
 done
 
-# Do upload from libp2p to litep2p up to 16MB because the connection breaks after that.
-for bytes in "${VALUES_ARRAY[@]:10:5}"; do
-    OUTPUT=$(RUST_LOG=info cargo run -- client --transport-layer "webrtc" --server-address "/ip4/127.0.0.1/udp/8888/webrtc-direct/certhash/${CERT_HASH}/p2p/12D3KooWBpZHDZu7YSbvPaPXKhkRNJvR7MkTJMQQAVBKx9mCqz3q" --upload-bytes $bytes --download-bytes 1024 | grep bandwidth)
-
-    result_line=$(echo "$OUTPUT" | cut -d ' ' -f5-13)
-    echo $result_line
-
-    uploaded_bandwidth=$(echo "$result_line" | cut -d' ' -f8-9 | head -n 1)
-    results_upload_libp2p_litep2p_webrtc[$bytes]="$uploaded_bandwidth"
-
-    results_download_libp2p_litep2p_webrtc[$bytes]="n/a"
-done
-
-for bytes in "${VALUES_ARRAY[@]:15}"; do
-    results_upload_libp2p_litep2p_webrtc[$bytes]="n/a"
-    results_download_libp2p_litep2p_webrtc[$bytes]="n/a"
-done
+oneGiB=${VALUES_ARRAY[20]}
+results_upload_libp2p_litep2p_webrtc[$oneGiB]="n/a"
+results_download_libp2p_litep2p_webrtc[$oneGiB]="n/a"
 
 # Kill the server
 kill $SERVER_PID

--- a/run_bandwidth.sh
+++ b/run_bandwidth.sh
@@ -239,9 +239,8 @@ kill $SERVER_PID
 # Markdown output
 echo
 echo "# Bandwidth Report"
-echo "| Operation  | Bytes      | Litep2p->Litep2p | Libp2p->Libp2p | Libp2p->Libp2p | Libp2p->Litep2p | Libp2p->Litep2p | Litep2p->Libp2p |"
-echo "|            |            | (TCP)            | (TCP)          | (WebRTC)       | (TCP)           | (WebRTC)        | (TCP)           |"
-echo "|------------|------------|------------------|----------------|----------------|-----------------|-----------------|-----------------|"
+echo "| Operation  | Bytes      | Litep2p->Litep2p (TCP) | Libp2p->Libp2p (TCP) | Libp2p->Libp2p (WebRTC) | Libp2p->Litep2p (TCP) | Libp2p->Litep2p (WebRTC) | Litep2p->Libp2p (TCP) |"
+echo "|------------|------------|------------------------|----------------------|-------------------------|-----------------------|--------------------------|-----------------------|"
 
 for bytes in $VALUES; do
     fmt_bytes=$(numfmt --to=iec-i --suffix=B $bytes)

--- a/smoldot-automation/Cargo.toml
+++ b/smoldot-automation/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "smoldot-automation"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+rouille = "3.6.2"
+serde = { version = "1.0.228", features = ["derive"] }
+utils = { path = "../utils" }

--- a/smoldot-automation/Cargo.toml
+++ b/smoldot-automation/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+headless_chrome = "1.0.20"
 rouille = "3.6.2"
 serde = { version = "1.0.228", features = ["derive"] }
 utils = { path = "../utils" }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing = "0.1.34"

--- a/smoldot-automation/src/main.rs
+++ b/smoldot-automation/src/main.rs
@@ -1,5 +1,5 @@
-use std::process::Command;
 use std::env;
+use std::process::Command;
 use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
@@ -26,11 +26,17 @@ fn main() -> Result<()> {
     tracing::debug!("Server is running. Press Ctrl+C to stop.");
 
     thread::sleep(Duration::from_secs(2));
-    run_browser(host, &params.peer, params.upload_bytes, params.download_bytes)?;
+    run_browser(
+        host,
+        &params.peer,
+        params.upload_bytes,
+        params.download_bytes,
+    )?;
 
     let durations = done_rx.recv()?;
 
-    println!("Uploaded {} bytes in {:.4}s bandwidth {}",
+    println!(
+        "Uploaded {} bytes in {:.4}s bandwidth {}",
         utils::format_bytes(params.upload_bytes as usize),
         durations.upload_seconds,
         utils::format_bandwidth(
@@ -39,7 +45,8 @@ fn main() -> Result<()> {
         )
     );
 
-    println!("Downloaded {} bytes in {:.4}s bandwidth {}",
+    println!(
+        "Downloaded {} bytes in {:.4}s bandwidth {}",
         utils::format_bytes(params.download_bytes as usize),
         durations.download_seconds,
         utils::format_bandwidth(
@@ -77,18 +84,10 @@ fn run_server(host: &str, tx: mpsc::Sender<Durations>) {
     });
 }
 
-fn run_browser(
-    host: &str,
-    peer: &str,
-    upload_bytes: u64,
-    download_bytes: u64,
-) -> Result<()> {
+fn run_browser(host: &str, peer: &str, upload_bytes: u64, download_bytes: u64) -> Result<()> {
     let url = format!(
         "http://{}/index.html?peer={}&upload_bytes={}&download_bytes={}&autorun=true",
-        host,
-        peer,
-        upload_bytes,
-        download_bytes,
+        host, peer, upload_bytes, download_bytes,
     );
 
     tracing::debug!("Opening browser at {}", url);
@@ -107,8 +106,11 @@ fn run_browser(
 
 fn build_wasm() -> Result<()> {
     if !is_wasm_target_installed()? {
-        return Err("wasm32-unknown-unknown target is not installed. Run 'rustup target add \
-        wasm32-unknown-unknown'".into());
+        return Err(
+            "wasm32-unknown-unknown target is not installed. Run 'rustup target add \
+        wasm32-unknown-unknown'"
+                .into(),
+        );
     }
 
     check_wasm_bindgen_version()?;
@@ -137,8 +139,10 @@ fn build_wasm() -> Result<()> {
     // generate wasm/js bindings
     let output = Command::new("wasm-bindgen")
         .current_dir(cwd)
-        .arg("--target").arg("web")
-        .arg("--out-dir").arg(&output_dir)
+        .arg("--target")
+        .arg("web")
+        .arg("--out-dir")
+        .arg(&output_dir)
         .arg(&wasm_path)
         .output()?;
 
@@ -167,14 +171,24 @@ fn parse_args(args: &[String]) -> Result<Params> {
     let peer = &args[1];
 
     let upload_bytes = args[2].parse::<u64>().map_err(|_| {
-        format!("Error: 'upload_bytes' must be a valid positive integer (found: '{}')", args[2])
+        format!(
+            "Error: 'upload_bytes' must be a valid positive integer (found: '{}')",
+            args[2]
+        )
     })?;
 
     let download_bytes = args[3].parse::<u64>().map_err(|_| {
-        format!("Error: 'download_bytes' must be a valid positive integer (found: '{}')", args[3])
+        format!(
+            "Error: 'download_bytes' must be a valid positive integer (found: '{}')",
+            args[3]
+        )
     })?;
 
-    Ok(Params { peer: peer.to_string(), upload_bytes, download_bytes })
+    Ok(Params {
+        peer: peer.to_string(),
+        upload_bytes,
+        download_bytes,
+    })
 }
 
 fn is_wasm_target_installed() -> Result<bool> {
@@ -187,7 +201,9 @@ fn is_wasm_target_installed() -> Result<bool> {
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    Ok(stdout.lines().any(|line| line.contains("wasm32-unknown-unknown")))
+    Ok(stdout
+        .lines()
+        .any(|line| line.contains("wasm32-unknown-unknown")))
 }
 
 fn check_wasm_bindgen_version() -> Result<()> {
@@ -201,10 +217,12 @@ fn check_wasm_bindgen_version() -> Result<()> {
     let output = Command::new("wasm-bindgen")
         .arg("--version")
         .output()
-        .map_err(|_| format!(
-            "wasm-bindgen-cli is not installed. Run 'cargo install wasm-bindgen-cli@={}'",
-            expected_version,
-        ))?;
+        .map_err(|_| {
+            format!(
+                "wasm-bindgen-cli is not installed. Run 'cargo install wasm-bindgen-cli@={}'",
+                expected_version,
+            )
+        })?;
 
     let actual_version_output = String::from_utf8_lossy(&output.stdout);
     let actual_version = actual_version_output
@@ -216,10 +234,9 @@ fn check_wasm_bindgen_version() -> Result<()> {
         return Err(format!(
             "wasm-bindgen-cli version mismatch. Expected {}, found {}. Run 'cargo install \
             wasm-bindgen-cli@={}'",
-            expected_version,
-            actual_version,
-            expected_version,
-        ).into());
+            expected_version, actual_version, expected_version,
+        )
+        .into());
     }
 
     Ok(())

--- a/smoldot-automation/src/main.rs
+++ b/smoldot-automation/src/main.rs
@@ -7,6 +7,10 @@ use std::time::Duration;
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
     let args: Vec<String> = env::args().collect();
     let params = parse_args(&args)?;
     let host = "127.0.0.1:8082";
@@ -15,11 +19,11 @@ fn main() -> Result<()> {
 
     let (done_tx, done_rx) = mpsc::channel();
 
-    thread::spawn(|| {
+    thread::spawn(move || {
         run_server(host, done_tx);
     });
 
-    println!("Server is running. Press Ctrl+C to stop.");
+    tracing::debug!("Server is running. Press Ctrl+C to stop.");
 
     thread::sleep(Duration::from_secs(2));
     run_browser(host, &params.peer, params.upload_bytes, params.download_bytes)?;
@@ -54,7 +58,7 @@ struct Durations {
 }
 
 fn run_server(host: &str, tx: mpsc::Sender<Durations>) {
-    println!("Starting web server on {}", host);
+    tracing::debug!("Starting web server on {}", host);
 
     rouille::start_server(host, move |request| {
         if request.method() == "POST" && request.url() == "/results" {
@@ -87,12 +91,28 @@ fn run_browser(
         download_bytes,
     );
 
-    println!("Opening browser at {}", url);
-    Command::new("open").arg(url).status()?;
+    tracing::debug!("Opening browser at {}", url);
+
+    let mut options = headless_chrome::LaunchOptions::default();
+    options.idle_browser_timeout = Duration::from_secs(120);
+
+    let browser = headless_chrome::Browser::new(options)?;
+    let tab = browser.new_tab()?;
+
+    tab.navigate_to(&url)?;
+    tab.wait_until_navigated()?;
+    tab.wait_for_element("#perf-finished")?;
     Ok(())
 }
 
 fn build_wasm() -> Result<()> {
+    if !is_wasm_target_installed()? {
+        return Err("wasm32-unknown-unknown target is not installed. Run 'rustup target add \
+        wasm32-unknown-unknown'".into());
+    }
+
+    check_wasm_bindgen_version()?;
+
     let cwd = env::current_dir()?;
 
     let smoldot_dir = cwd.join("smoldot-perf");
@@ -125,7 +145,7 @@ fn build_wasm() -> Result<()> {
     if !output.status.success() {
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
-        eprintln!("{}\n{}", stdout, stderr);
+        tracing::error!("{}\n{}", stdout, stderr);
         return Err("build failed".into());
     }
 
@@ -155,4 +175,52 @@ fn parse_args(args: &[String]) -> Result<Params> {
     })?;
 
     Ok(Params { peer: peer.to_string(), upload_bytes, download_bytes })
+}
+
+fn is_wasm_target_installed() -> Result<bool> {
+    let output = Command::new("rustup")
+        .args(&["target", "list", "--installed"])
+        .output()?;
+
+    if !output.status.success() {
+        return Err("failed to execute rustup".into());
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(stdout.lines().any(|line| line.contains("wasm32-unknown-unknown")))
+}
+
+fn check_wasm_bindgen_version() -> Result<()> {
+    let manifest_content = std::fs::read_to_string("smoldot-perf/Cargo.toml")?;
+    let expected_version = manifest_content
+        .lines()
+        .find(|line| line.trim().starts_with("wasm-bindgen ="))
+        .and_then(|line| line.split('"').nth(1))
+        .ok_or("Could not find wasm-bindgen version in smoldot-perf/Cargo.toml")?;
+
+    let output = Command::new("wasm-bindgen")
+        .arg("--version")
+        .output()
+        .map_err(|_| format!(
+            "wasm-bindgen-cli is not installed. Run 'cargo install wasm-bindgen-cli@={}'",
+            expected_version,
+        ))?;
+
+    let actual_version_output = String::from_utf8_lossy(&output.stdout);
+    let actual_version = actual_version_output
+        .split_whitespace()
+        .nth(1)
+        .ok_or("Could not parse wasm-bindgen version")?;
+
+    if actual_version != expected_version {
+        return Err(format!(
+            "wasm-bindgen-cli version mismatch. Expected {}, found {}. Run 'cargo install \
+            wasm-bindgen-cli@={}'",
+            expected_version,
+            actual_version,
+            expected_version,
+        ).into());
+    }
+
+    Ok(())
 }

--- a/smoldot-automation/src/main.rs
+++ b/smoldot-automation/src/main.rs
@@ -9,6 +9,7 @@ type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 fn main() -> Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_ansi(false)
         .init();
 
     let args: Vec<String> = env::args().collect();

--- a/smoldot-automation/src/main.rs
+++ b/smoldot-automation/src/main.rs
@@ -1,0 +1,158 @@
+use std::process::Command;
+use std::env;
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+fn main() -> Result<()> {
+    let args: Vec<String> = env::args().collect();
+    let params = parse_args(&args)?;
+    let host = "127.0.0.1:8082";
+
+    build_wasm()?;
+
+    let (done_tx, done_rx) = mpsc::channel();
+
+    thread::spawn(|| {
+        run_server(host, done_tx);
+    });
+
+    println!("Server is running. Press Ctrl+C to stop.");
+
+    thread::sleep(Duration::from_secs(2));
+    run_browser(host, &params.peer, params.upload_bytes, params.download_bytes)?;
+
+    let durations = done_rx.recv()?;
+
+    println!("Uploaded {} bytes in {:.4}s bandwidth {}",
+        utils::format_bytes(params.upload_bytes as usize),
+        durations.upload_seconds,
+        utils::format_bandwidth(
+            Duration::from_secs_f64(durations.upload_seconds),
+            params.upload_bytes as usize,
+        )
+    );
+
+    println!("Downloaded {} bytes in {:.4}s bandwidth {}",
+        utils::format_bytes(params.download_bytes as usize),
+        durations.download_seconds,
+        utils::format_bandwidth(
+            Duration::from_secs_f64(durations.download_seconds),
+            params.download_bytes as usize,
+        )
+    );
+
+    Ok(())
+}
+
+#[derive(serde::Deserialize)]
+struct Durations {
+    upload_seconds: f64,
+    download_seconds: f64,
+}
+
+fn run_server(host: &str, tx: mpsc::Sender<Durations>) {
+    println!("Starting web server on {}", host);
+
+    rouille::start_server(host, move |request| {
+        if request.method() == "POST" && request.url() == "/results" {
+            let durations: Durations = rouille::try_or_400!(rouille::input::json_input(request));
+            let _ = tx.send(durations);
+            return rouille::Response::empty_204();
+        }
+
+        let response = rouille::match_assets(request, "./smoldot-perf");
+
+        if response.is_success() {
+            response
+        } else {
+            rouille::Response::html("<h1>404 Not Found</h1>").with_status_code(404)
+        }
+    });
+}
+
+fn run_browser(
+    host: &str,
+    peer: &str,
+    upload_bytes: u64,
+    download_bytes: u64,
+) -> Result<()> {
+    let url = format!(
+        "http://{}/index.html?peer={}&upload_bytes={}&download_bytes={}&autorun=true",
+        host,
+        peer,
+        upload_bytes,
+        download_bytes,
+    );
+
+    println!("Opening browser at {}", url);
+    Command::new("open").arg(url).status()?;
+    Ok(())
+}
+
+fn build_wasm() -> Result<()> {
+    let cwd = env::current_dir()?;
+
+    let smoldot_dir = cwd.join("smoldot-perf");
+    let output_dir = smoldot_dir.join("pkg");
+
+    let target_dir = cwd.join("target/wasm32-unknown-unknown/release");
+    let wasm_path = target_dir.join("smoldot_perf.wasm");
+
+    // build wasm from rust
+    let output = Command::new("cargo")
+        .current_dir(smoldot_dir)
+        .args(&["build", "--release", "--target", "wasm32-unknown-unknown"])
+        .output()?;
+
+    if !output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        eprintln!("cargo build failed: \n{}\n{}", stdout, stderr);
+        return Err("build failed".into());
+    }
+
+    // generate wasm/js bindings
+    let output = Command::new("wasm-bindgen")
+        .current_dir(cwd)
+        .arg("--target").arg("web")
+        .arg("--out-dir").arg(&output_dir)
+        .arg(&wasm_path)
+        .output()?;
+
+    if !output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        eprintln!("{}\n{}", stdout, stderr);
+        return Err("build failed".into());
+    }
+
+    Ok(())
+}
+
+struct Params {
+    peer: String,
+    upload_bytes: u64,
+    download_bytes: u64,
+}
+
+fn parse_args(args: &[String]) -> Result<Params> {
+    if args.len() < 4 {
+        eprintln!("Usage: {} <peer> <upload_bytes> <download_bytes>", args[0]);
+        return Err("Missing required arguments".into());
+    }
+
+    let peer = &args[1];
+
+    let upload_bytes = args[2].parse::<u64>().map_err(|_| {
+        format!("Error: 'upload_bytes' must be a valid positive integer (found: '{}')", args[2])
+    })?;
+
+    let download_bytes = args[3].parse::<u64>().map_err(|_| {
+        format!("Error: 'download_bytes' must be a valid positive integer (found: '{}')", args[3])
+    })?;
+
+    Ok(Params { peer: peer.to_string(), upload_bytes, download_bytes })
+}

--- a/smoldot-perf/Cargo.toml
+++ b/smoldot-perf/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "smoldot-perf"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+smoldot = { git = "https://github.com/ChainSafe/smoldot", branch = "haiko-webrtc-perf", default-features = false }
+rand = { version = "0.9.2", default-features = false, features = ["alloc", "std_rng"] }
+wasm-bindgen = "0.2.106"
+wasm-bindgen-futures = "0.4.50"
+web-sys = { version = "0.3", features = ["console"] }
+js-sys = "0.3.77"
+base64 = "0.22.1"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+smoldot-light = { git = "https://github.com/ChainSafe/smoldot", branch = "haiko-webrtc-perf", default-features = false }
+wasm-bindgen = "0.2.106"
+web-sys = { version = "0.3", features = ["console"] }
+getrandom = { version = "0.2", features = ["js"] }

--- a/smoldot-perf/index.html
+++ b/smoldot-perf/index.html
@@ -1,0 +1,528 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Smoldot WebRTC WASM litep2p-perf</title>
+    <style>
+         body {
+            font-family: Arial, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+        button {
+            padding: 10px 20px;
+            font-size: 16px;
+            cursor: pointer;
+            background-color: #007bff;
+            color: white;
+            border: none;
+            border-radius: 5px;
+        }
+        button:hover {
+            background-color: #0056b3;
+        }
+        #main-controls {
+            width: fit-content;
+            margin-bottom: 20px;
+        }
+        #selectors-container {
+            display: flex;
+            gap: 20px;
+        }
+        fieldset {
+            border: 1px solid #ccc;
+            border-radius: 5px;
+            padding: 15px;
+            margin-bottom: 20px;
+            width: 300px;
+        }
+        legend {
+            font-weight: bold;
+            padding: 0 5px;
+        }
+        div {
+            margin-bottom: 10px;
+        }
+        #controls-container {
+            display: flex;
+            width: 100%;
+            margin-top: 20px;
+        }
+        #peer-address {
+            flex-grow: 1;
+            min-width: 0;
+            margin-right: 10px;
+            font-size: 16px;
+            padding: 10px;
+        }
+        label {
+            margin-right: 10px;
+            cursor: pointer;
+        }
+        .customBytesInput {
+            margin-left: 5px;
+            width: 100px;
+        }
+        button {
+            margin-right: 10px;
+        }
+        #output {
+            margin-top: 20px;
+            padding: 10px;
+            background-color: #f8f9fa;
+            border-radius: 5px;
+            min-height: 100px;
+            white-space: pre-wrap;
+        }
+    </style>
+</head>
+<body>
+<h1>Smoldot WebRTC WASM litep2p-perf Client</h1>
+
+<div id="main-controls">
+    <div id="selectors-container">
+        <fieldset id="upload-fieldset" class="byte-selector">
+            <legend>Upload</legend>
+
+            <div>
+                <input type="radio" id="kb1-upload" name="bytes-upload" checked value="1024">
+                <label for="kb1-upload">1 KB</label>
+            </div>
+            <div>
+                <input type="radio" id="mb1-upload" name="bytes-upload" value="1048576">
+                <label for="mb1-upload">1 MB</label>
+            </div>
+            <div>
+                <input type="radio" id="gb1-upload" name="bytes-upload" value="1073741824">
+                <label for="gb1-upload">1 GB</label>
+            </div>
+            <div>
+                <input type="radio" id="custom-upload" name="bytes-upload" value="custom">
+                <label for="custom-upload">Custom:</label>
+                <input type="number" id="customBytes-upload" name="customBytesValue-upload" class="customBytesInput" placeholder="Enter bytes">
+            </div>
+        </fieldset>
+
+        <fieldset id="download-fieldset" class="byte-selector">
+            <legend>Download</legend>
+
+            <div>
+                <input type="radio" id="kb1-download" name="bytes-download" checked value="1024">
+                <label for="kb1-download">1 KB</label>
+            </div>
+            <div>
+                <input type="radio" id="mb1-download" name="bytes-download" value="1048576">
+                <label for="mb1-download">1 MB</label>
+            </div>
+            <div>
+                <input type="radio" id="gb1-download" name="bytes-download" value="1073741824">
+                <label for="gb1-download">1 GB</label>
+            </div>
+            <div>
+                <input type="radio" id="custom-download" name="bytes-download" value="custom">
+                <label for="custom-download">Custom:</label>
+                <input type="number" id="customBytes-download" name="customBytesValue-download" class="customBytesInput" placeholder="Enter bytes">
+            </div>
+        </fieldset>
+    </div>
+
+    <div id="controls-container">
+        <input
+            id="peer-address"
+            type="text"
+            placeholder="Enter peer multiaddress"
+        >
+        <button id="run" onclick="run()">Run</button>
+    </div>
+    <div id="output"></div>
+</div>
+
+<script type="module">
+  import {multiaddr, CODE_IP4, CODE_UDP, CODE_CERTHASH} from 'https://esm.sh/@multiformats/multiaddr@12.5.1';
+  import {base64url} from 'https://esm.sh/multiformats@13.4.0/bases/base64';
+  import init, {run_client} from './pkg/smoldot_perf.js';
+
+  const maxMessageSize = 16384;
+
+  window.run = async function () {
+    const output = document.getElementById('output');
+    output.textContent = 'Loading WASM module...\n';
+
+    try {
+      await init();
+      output.textContent += 'WASM module loaded successfully!\n';
+    } catch (error) {
+      output.textContent += `Error: ${error}\n`;
+    }
+
+    output.textContent += 'Running litep2p-perf protocol...\n';
+
+    const uploadFieldset = document.getElementById('upload-fieldset');
+    const downloadFieldset = document.getElementById('download-fieldset');
+    const uploadBytes = getSelectedBytes(uploadFieldset);
+    const downloadBytes = getSelectedBytes(downloadFieldset);
+    const peer = document.getElementById('peer-address').value;
+
+    await run_client(uploadBytes, downloadBytes, peer).catch(error => {
+      output.textContent += `\n\n${error}\n`;
+    });
+  };
+
+  const channels = {}; // channelId -> DataChannel
+
+  export function sendTo(channelId, data) {
+    const channel = channels[channelId];
+
+    if (!channel) {
+      throw new Error(`JS: channel ${channelId} not found`);
+    }
+
+    if (channel.readyState !== 'open') {
+      throw new Error(`JS: channel ${channelId} is not in ready state`);
+    }
+
+    channel.send(data);
+  }
+
+  globalThis.sendTo = sendTo;
+
+  export async function sendResults(uploadSeconds, downloadSeconds) {
+    await fetch(
+      'http://127.0.0.1:8082/results',
+      {
+        method: 'POST',
+        body: JSON.stringify(
+          {
+            'upload_seconds': uploadSeconds,
+            'download_seconds': downloadSeconds
+          }
+        ),
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }
+    );
+  }
+
+  globalThis.sendResults = sendResults;
+
+  export async function generateCertificate() {
+    return await RTCPeerConnection.generateCertificate({
+      name: 'ECDSA',
+      hash: 'SHA-256',
+      namedCurve: 'P-256',
+    });
+  }
+
+  globalThis.generateCertificate = generateCertificate;
+
+  export function getCertificateMultihash(certificate) {
+    const fp = certificate.getFingerprints().find(f => f.algorithm.toUpperCase() === 'SHA-256');
+    if (!fp) throw new Error('No SHA-256 fingerprint on certificate');
+
+    const clean = fp.value.replace(/:/g, '');
+    const out = new Uint8Array(clean.length / 2);
+
+    for (let i = 0; i < out.length; i++) {
+      out[i] = Number.parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+    }
+
+    const mh = new Uint8Array(2 + 32);
+    mh[0] = 0x12;
+    mh[1] = 0x20;
+    mh.set(out, 2);
+    return mh;
+  }
+
+  globalThis.getCertificateMultihash = getCertificateMultihash;
+
+  export function now() {
+    return performance.now();
+  }
+
+  globalThis.now = now;
+
+  globalThis.smoldotGlue = {
+    // datachannel has been opened by the remote
+    onDatachannelOpen: (channelId) => {
+      console.log(`JS: glue stub onDatachannelOpen() channelId: ${channelId}`);
+    },
+    // locally opened datachannel is ready for bizniz
+    onDatachannelReady: (channelId) => {
+      console.log(`JS: glue stub onDatachannelReady() channelId: ${channelId}`);
+    },
+    onDatachannelClose: (channelId) => {
+      console.log(`JS: glue stub onDatachannelClose(): channelId: ${channelId}`);
+      delete channels[channelId];
+    },
+    onDatachannelError: (channelId, msg) => {
+      console.log(`JS: glue stub onDatachannelError(): channelId: ${channelId}, msg: ${msg}`);
+      delete channels[channelId];
+    },
+    onMessage: (channelId, _data) => {
+      console.log(`JS: glue stub onMessage(): channelId: ${channelId}`);
+    },
+    onTimeElapsed: () => {
+      console.log(`JS: glue stub onTimeElapsed()`);
+    }
+  }
+
+  export function setGlue(glue) {
+    globalThis.smoldotGlue = glue;
+  }
+
+  globalThis.setGlue = setGlue;
+
+  export function createDatachannel() {
+    const dc = globalThis.rtcPeerConnection.createDataChannel('', {
+      ordered: true,
+    });
+
+    dc.onopen = event => globalThis.smoldotGlue.onDatachannelReady(event.target.id);
+
+    configureDatachannel(dc);
+
+    // Make sure we resume sending after pausing for the send queue to drain.
+    dc.onbufferedamountlow = () => {
+      globalThis.smoldotGlue.onTimeElapsed();
+    };
+
+    return dc.id;
+  }
+
+  globalThis.createDatachannel = createDatachannel;
+
+  export async function dialWebRtcDirect(address, certificate) {
+    const pc = new RTCPeerConnection({certificates: [certificate], iceServers: []});
+    globalThis.rtcPeerConnection = pc;
+
+    pc.ondatachannel = event => {
+      channels[event.channel.id] = event.channel;
+
+      event.channel.onmessage = dataEvent => {
+        const data = new Uint8Array(dataEvent.data);
+        globalThis.smoldotGlue.onMessage(event.channel.id, data);
+      };
+
+      event.channel.onclose = () => {
+        globalThis.smoldotGlue.onDatachannelClose(event.channel.id);
+      }
+
+      event.channel.onerror = err => {
+        const msg = `${err}`;
+        globalThis.smoldotGlue.onDatachannelError(event.channel.id, msg);
+      }
+
+      globalThis.smoldotGlue.onDatachannelOpen(event.channel.id);
+    };
+
+    const dc = pc.createDataChannel('', {
+      negotiated: true,
+      id: 0,
+      ordered: true,
+    });
+
+    configureDatachannel(dc);
+
+    // Build answer and offer with patched ICE ufrag/pwd with libp2p tag
+    const ufrag = `libp2p+webrtc+v1/${randomString()}`;
+
+    const offer = await pc.createOffer({offerToReceiveAudio: false, offerToReceiveVideo: false});
+    offer.sdp = mungeOffer(offer.sdp, ufrag);
+
+    await pc.setLocalDescription(offer);
+
+    const ma = multiaddr(address);
+    const componentsByCode = {};
+    ma.getComponents().forEach(c => componentsByCode[c.code] = c.value);
+
+    const {[CODE_IP4]: ip, [CODE_UDP]: port, [CODE_CERTHASH]: certhash} = componentsByCode;
+    const answer = buildAnswer(ip, port, certhash, ufrag);
+
+    await pc.setRemoteDescription(answer);
+  }
+
+  globalThis.dialWebRtcDirect = dialWebRtcDirect;
+
+  export function scheduleTick() {
+    setTimeout(() => {
+      globalThis.smoldotGlue.onTimeElapsed();
+    }, 100);
+  }
+
+  globalThis.scheduleTick = scheduleTick;
+
+  function configureDatachannel(dc) {
+    channels[dc.id] = dc;
+    dc.binaryType = 'arraybuffer';
+
+    dc.onmessage = event => {
+      const data = new Uint8Array(event.data);
+      // console.log(`JS: ${data.length} bytes received on channel ${dc.id}`); //: ${data}`);
+      globalThis.smoldotGlue.onMessage(dc.id, data);
+    };
+
+    dc.onclose = () => {
+      globalThis.smoldotGlue.onDatachannelClose(dc.id);
+      delete channels[dc.id];
+    };
+
+    dc.onerror = err => {
+      const msg = `${err}`;
+      globalThis.smoldotGlue.onDatachannelError(dc.id, msg);
+      delete channels[dc.id];
+    };
+  }
+
+  function buildAnswer(ip, port, certhash, ufrag) {
+    // Single host candidate, ICE-lite, DTLS passive, SCTP port 5000, max message size 16KiB.
+    const sdp = [
+      'v=0',
+      'o=- 0 0 IN IP4 127.0.0.1',
+      's=-',
+      't=0 0',
+      'a=ice-lite',
+      `a=fingerprint:sha-256 ${certhashToSdpFingerprint(certhash)}`,
+      `a=ice-ufrag:${ufrag}`,
+      `a=ice-pwd:${ufrag}`,
+      'a=setup:passive',
+      'm=application 9 UDP/DTLS/SCTP webrtc-datachannel',
+      `c=IN IP4 ${ip}`,
+      'a=mid:0',
+      `a=candidate:1 1 UDP 2130706431 ${ip} ${port} typ host`,
+      'a=end-of-candidates',
+      'a=sctp-port:5000',
+      `a=max-message-size:${maxMessageSize}`,
+    ].join('\r\n') + '\r\n';
+
+    return {
+      type: 'answer',
+      sdp: sdp,
+    }
+  }
+
+  function mungeOffer(sdp, ufrag) {
+    return sdp
+      .replace(/a=ice-ufrag:.+\r\n/, `a=ice-ufrag:${ufrag}\r\n`)
+      .replace(/a=ice-pwd:.+\r\n/, `a=ice-pwd:${ufrag}\r\n`)
+      .replace(/a=max-message-size:.+\r\n/, `a=max-message-size:${maxMessageSize}\r\n`);
+  }
+
+  function certhashToSdpFingerprint(certhash) {
+    // certhash is multibase; 'u' means base64url (no padding)
+    if (!certhash || certhash[0] !== 'u') {
+      throw new Error('Expected base64url multibase certhash starting with "u"');
+    }
+
+    const mh = base64url.decode(certhash);
+    // Multihash: 0x12 = sha2-256, 0x20 = 32 bytes
+    if (mh.length !== 34 || mh[0] !== 0x12 || mh[1] !== 0x20) {
+      throw new Error('Unsupported certhash multihash; expected sha2-256/32');
+    }
+
+    const digest = mh.slice(2); // 32-byte SHA-256
+    return Array.from(digest)
+      .map(b => b.toString(16).padStart(2, '0'))
+      .join(':')
+      .toUpperCase();
+  }
+
+  function randomString(len = 5) {
+    const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+    const arr = new Uint8Array(len);
+    crypto.getRandomValues(arr);
+    let s = '';
+    for (let i = 0; i < len; i++) s += chars[arr[i] % chars.length];
+    return s;
+  }
+
+  function getSelectedBytes(fieldsetElement) {
+    const selectedRadio = fieldsetElement.querySelector('input[type="radio"]:checked');
+
+    if (!selectedRadio) {
+      const output = document.getElementById('output');
+      output.textContent += 'No bytes specified for a fieldset!\n';
+      return BigInt(0);
+    }
+
+    if (selectedRadio.value === 'custom') {
+      const customInput = fieldsetElement.querySelector('.customBytesInput');
+      return BigInt(parseInt(customInput.value) || 0);
+    } else {
+      return BigInt(parseInt(selectedRadio.value));
+    }
+  }
+</script>
+
+<script>
+  function initializeByteSelector(fieldsetElement) {
+    const customRadio = fieldsetElement.querySelector('input[value="custom"]');
+    const customInput = fieldsetElement.querySelector('.customBytesInput');
+    const otherRadios = fieldsetElement.querySelectorAll('input[type="radio"]:not([value="custom"])');
+
+    customInput.disabled = !customRadio.checked;
+
+    customRadio.addEventListener('change', () => {
+      if (customRadio.checked) {
+        customInput.disabled = false;
+        customInput.focus();
+      }
+    });
+
+    otherRadios.forEach(radio => {
+      radio.addEventListener('change', () => {
+        if (radio.checked) {
+          customInput.disabled = true;
+          customInput.value = '';
+        }
+      });
+    });
+
+    customInput.addEventListener('focus', () => {
+      customRadio.checked = true;
+      customInput.disabled = false;
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const setCustomValueFromParam = (fieldsetElement, value) => {
+      if (value === null) {
+        return;
+      }
+
+      const numericValue = parseInt(value, 10);
+      if (isNaN(numericValue)) {
+        return;
+      }
+
+      const customRadio = fieldsetElement.querySelector('input[value="custom"]');
+      const customInput = fieldsetElement.querySelector('.customBytesInput');
+
+      if (customRadio && customInput) {
+        customInput.value = numericValue;
+        customRadio.checked = true;
+      }
+    };
+
+    const urlParams = new URLSearchParams(window.location.search);
+
+    const uploadFieldset = document.getElementById('upload-fieldset');
+    const downloadFieldset = document.getElementById('download-fieldset');
+
+    setCustomValueFromParam(uploadFieldset, urlParams.get('upload_bytes'));
+    setCustomValueFromParam(downloadFieldset, urlParams.get('download_bytes'));
+
+    document.querySelectorAll('.byte-selector').forEach(fieldset => {
+      initializeByteSelector(fieldset);
+    });
+
+    document.getElementById('peer-address').value = urlParams.get('peer') || '';
+
+    if (urlParams.get('autorun') === 'true') {
+      document.getElementById('run').click();
+    }
+  });
+</script>
+</body>
+</html>

--- a/smoldot-perf/index.html
+++ b/smoldot-perf/index.html
@@ -203,6 +203,11 @@
         }
       }
     );
+
+    // This is added to the DOM so smoldot-automation can wait for it before shutting down the browser.
+    const finishedDiv = document.createElement('div');
+    finishedDiv.id = 'perf-finished';
+    document.getElementById('output').appendChild(finishedDiv);
   }
 
   globalThis.sendResults = sendResults;

--- a/smoldot-perf/src/lib.rs
+++ b/smoldot-perf/src/lib.rs
@@ -1,0 +1,621 @@
+mod perf;
+
+use rand::{RngCore, SeedableRng, rngs::StdRng};
+use std::cell::RefCell;
+use std::fmt::{Display, Formatter};
+use std::rc::Rc;
+use std::time::Duration;
+use smoldot::libp2p::{
+    collection,
+    connection::{noise, webrtc_framing},
+    read_write::ReadWrite,
+};
+
+use smoldot::libp2p::collection::ConnectionId;
+use wasm_bindgen::prelude::*;
+use web_sys::console;
+use smoldot::libp2p::connection::webrtc_framing::Error;
+
+#[wasm_bindgen]
+extern "C" {
+    async fn generateCertificate() -> JsValue;
+
+    #[wasm_bindgen(catch)]
+    fn getCertificateMultihash(certificate: JsValue) -> Result<js_sys::Uint8Array, JsValue>;
+
+    fn setGlue(glue: js_sys::Object);
+
+    #[wasm_bindgen(catch)]
+    async fn dialWebRtcDirect(
+        address: String,
+        certificate: JsValue,
+    ) -> Result<JsValue, JsValue>;
+
+    #[wasm_bindgen(catch)]
+    fn sendTo(channel_id: u64, data: &[u8]) -> Result<(), JsValue>;
+
+    #[wasm_bindgen(catch)]
+    fn createDatachannel() -> Result<js_sys::Number, JsValue>;
+
+    fn scheduleTick();
+
+    fn now() -> js_sys::Number;
+
+    #[wasm_bindgen(catch)]
+    fn sendResults(upload_duration: f64, download_duration: f64) -> Result<(), JsValue>;
+}
+
+#[wasm_bindgen]
+pub async fn run_client(
+    upload_bytes: u64,
+    download_bytes: u64,
+    peer_address: String,
+) -> Result<(), String> {
+    console::log_1(&format!("dialing: {}", peer_address).into());
+
+    let mut client = Client::new(upload_bytes, download_bytes, peer_address)
+        .await
+        .map_err(|e| format!("client error: {:?}", e))?;
+
+    client
+        .run()
+        .await
+        .map_err(|e| format!("client run() error: {:?}", e))?;
+
+    Ok(())
+}
+
+type DatachannelId = u64;
+
+// A wasm-safe monotonic time type compatible with smoldot's Duration arithmetic.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct Instant(u64);
+
+impl Instant {
+    fn now() -> Self {
+        // performance.now() returns fractional milliseconds. 
+        // Multiplying by 1000 gives us microsecond precision.
+        Self((now().as_f64().unwrap() * 1000.0) as u64)
+    }
+}
+
+impl Display for Instant {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl core::ops::Add<Duration> for Instant {
+    type Output = Self;
+    fn add(self, rhs: Duration) -> Self::Output {
+        Self(self.0.saturating_add(rhs.as_millis() as u64))
+    }
+}
+
+impl core::ops::Sub<Duration> for Instant {
+    type Output = Self;
+    fn sub(self, rhs: Duration) -> Self::Output {
+        Self(self.0.saturating_sub(rhs.as_millis() as u64))
+    }
+}
+
+impl core::ops::Sub for Instant {
+    type Output = Duration;
+    fn sub(self, rhs: Self) -> Self::Output {
+        // Calculate duration in microseconds
+        Duration::from_micros(self.0.saturating_sub(rhs.0))
+    }
+}
+
+struct Client {
+    noise_key: noise::NoiseKey,
+    local_certhash: Vec<u8>,
+    remote_certhash: Vec<u8>,
+    inner: Rc<RefCell<ClientInner>>,
+}
+
+impl Client {
+    async fn new(
+        upload_bytes: u64,
+        download_bytes: u64,
+        peer_address: String,
+    ) -> Result<Self, String> {
+        let mut rng = StdRng::seed_from_u64(0xC0FFEE);
+        let mut randomness_seed = [0u8; 32];
+        rng.fill_bytes(&mut randomness_seed);
+
+        let config = collection::Config {
+            randomness_seed,
+            capacity: 4,
+            max_inbound_substreams: 8,
+            max_protocol_name_len: 64,
+            handshake_timeout: Duration::from_secs(10),
+            ping_protocol: "/ipfs/ping/1.0.0".to_string(),
+        };
+
+        let mut ed25519_private = [0u8; 32];
+        rng.fill_bytes(&mut ed25519_private);
+        let mut noise_key = [0u8; 32];
+        rng.fill_bytes(&mut noise_key);
+        let noise_key = build_noise_key(&ed25519_private, &noise_key);
+
+        let local_cert = generateCertificate().await;
+
+        let cert_fp =
+            getCertificateMultihash(local_cert.clone()).map_err(|e| format!("{:?}", e))?;
+
+        let mut local_certhash = [0u8; 34];
+        cert_fp.copy_to(&mut local_certhash);
+        let local_certhash = Vec::from(local_certhash);
+
+        let remote_certhash = parse_certhash_from_multiaddr(&peer_address)
+            .map_err(|e| format!("bad certhash in multiaddr: {e}"))?;
+
+        let network = collection::Network::new(config);
+
+        Ok(Self {
+            noise_key,
+            local_certhash,
+            remote_certhash,
+            inner: Rc::new(RefCell::new(ClientInner {
+                peer_address,
+                local_cert,
+                network,
+                task: None,
+                connection_id: None,
+                handshake_channel: 0,
+                handshake_done: false,
+                handshake_rw: empty_read_write(),
+                perf_channel: None,
+                perf_rw: empty_read_write(),
+                perf_framing: webrtc_framing::WebRtcFraming::new(),
+                perf_stream: Some(perf::PerfStream::new(upload_bytes, download_bytes)),
+            })),
+        })
+    }
+
+    async fn run(&mut self) -> Result<(), String> {
+        let glue = js_sys::Object::new();
+
+        // onDatachannelOpen(channelId: Number)
+        {
+            let func =
+                Closure::<dyn FnMut(js_sys::Number)>::new(move |_channel_id: js_sys::Number| {
+                    console::log_1(&"remote unexpectedly opened a substream. ignoring".into());
+                });
+            js_sys::Reflect::set(
+                glue.as_ref(),
+                &JsValue::from_str("onDatachannelOpen"),
+                func.as_ref().unchecked_ref(),
+            )
+                .unwrap();
+            func.forget();
+        }
+
+        // onDatachannelReady(channelId: Number)
+        {
+            let inner_rc = Rc::clone(&self.inner);
+
+            let func =
+                Closure::<dyn FnMut(js_sys::Number)>::new(move |channel_id: js_sys::Number| {
+                    let channel_id = channel_id.as_f64().unwrap() as DatachannelId;
+                    let mut this = inner_rc.borrow_mut();
+                    this.on_datachannel_ready(channel_id);
+                });
+            js_sys::Reflect::set(
+                glue.as_ref(),
+                &JsValue::from_str("onDatachannelReady"),
+                func.as_ref().unchecked_ref(),
+            )
+                .unwrap();
+            func.forget();
+        }
+
+        // onDatachannelClose(channelId: Number)
+        {
+            let inner_rc = Rc::clone(&self.inner);
+
+            let func =
+                Closure::<dyn FnMut(js_sys::Number)>::new(move |channel_id: js_sys::Number| {
+                    let channel_id = channel_id.as_f64().unwrap() as DatachannelId;
+                    let mut this = inner_rc.borrow_mut();
+                    this.on_datachannel_close(channel_id);
+                });
+            js_sys::Reflect::set(
+                glue.as_ref(),
+                &JsValue::from_str("onDatachannelClose"),
+                func.as_ref().unchecked_ref(),
+            )
+                .unwrap();
+            func.forget();
+        }
+
+        // onDatachannelError(channelId: Number, message: String)
+        {
+            let inner_rc = Rc::clone(&self.inner);
+
+            let func = Closure::<dyn FnMut(js_sys::Number, js_sys::JsString)>::new(
+                move |channel_id: js_sys::Number, msg: js_sys::JsString| {
+                    let channel_id = channel_id.as_f64().unwrap() as DatachannelId;
+                    let mut this = inner_rc.borrow_mut();
+                    this.on_datachannel_error(channel_id, msg);
+                },
+            );
+            js_sys::Reflect::set(
+                glue.as_ref(),
+                &JsValue::from_str("onDatachannelError"),
+                func.as_ref().unchecked_ref(),
+            )
+                .unwrap();
+            func.forget();
+        }
+
+        // onMessage(channelId: Number, data: Uint8Array)
+        {
+            let inner_rc = Rc::clone(&self.inner);
+
+            let func = Closure::<dyn FnMut(js_sys::Number, js_sys::Uint8Array)>::new(
+                move |channel_id: js_sys::Number, data: js_sys::Uint8Array| {
+                    let channel_id = channel_id.as_f64().unwrap() as DatachannelId;
+                    let data = data.to_vec();
+                    let mut this = inner_rc.borrow_mut();
+
+                    if channel_id == this.handshake_channel && !this.handshake_done {
+                        this.drive_handshake(channel_id, &data);
+                    } else if this.perf_channel.is_some_and(|c| c == channel_id) {
+                        this.on_message(channel_id, &data);
+                    } else if !this.handshake_done {
+                        console::log_1(&format!(
+                            "got message on unknown channel {channel_id}. ignoring"
+                        ).into());
+                    }
+                },
+            );
+            js_sys::Reflect::set(
+                glue.as_ref(),
+                &JsValue::from_str("onMessage"),
+                func.as_ref().unchecked_ref(),
+            )
+                .unwrap();
+            func.forget();
+        }
+
+        // onTimeElapsed()
+        {
+            let inner_rc = Rc::clone(&self.inner);
+
+            let func =
+                Closure::<dyn FnMut()>::new(move || {
+                    inner_rc.borrow_mut().on_time_elapsed();
+                });
+            js_sys::Reflect::set(
+                glue.as_ref(),
+                &JsValue::from_str("onTimeElapsed"),
+                func.as_ref().unchecked_ref(),
+            )
+                .unwrap();
+            func.forget();
+        }
+
+        setGlue(glue);
+
+        // This is put in a scope so that `inner` is not "held across an await point".
+        {
+            let mut inner = self.inner.borrow_mut();
+            let (connection_id, mut task) = inner.network.insert_multi_stream(
+                Instant::now(),
+                collection::MultiStreamHandshakeKind::WebRtc {
+                    is_initiator: true,
+                    noise_key: &self.noise_key,
+                    local_tls_certificate_multihash: self.local_certhash.clone(),
+                    remote_tls_certificate_multihash: self.remote_certhash.clone(),
+                },
+                16,
+                None,
+            );
+
+            task.add_substream(inner.handshake_channel, true);
+            inner.task = Some(task);
+            inner.connection_id = Some(connection_id);
+        }
+
+        let (peer_address, local_cert) = {
+            let this = self.inner.borrow();
+            (this.peer_address.clone(), this.local_cert.clone())
+        };
+
+        dialWebRtcDirect(peer_address, local_cert)
+            .await
+            .map_err(|e| format!("dial error: {:?}", e))?;
+
+        Ok(())
+    }
+}
+
+struct ClientInner {
+    peer_address: String,
+    local_cert: JsValue,
+    network: collection::Network<Option<String>, Instant>,
+    task: Option<collection::MultiStreamConnectionTask<Instant, DatachannelId>>,
+    connection_id: Option<ConnectionId>,
+    handshake_channel: DatachannelId,
+    handshake_done: bool,
+    handshake_rw: ReadWrite<Instant>,
+    perf_channel: Option<DatachannelId>,
+    perf_rw: ReadWrite<Instant>,
+    perf_framing: webrtc_framing::WebRtcFraming,
+    perf_stream: Option<perf::PerfStream>,
+}
+
+impl ClientInner {
+    fn on_datachannel_ready(&mut self, channel_id: DatachannelId) {
+        // perf channel should be the only one opened after handshake
+        self.perf_channel = Some(channel_id);
+
+        self.perf_rw.now = Instant::now();
+        self.perf_rw.wake_up_asap();
+
+        // Kick off protocol negotiation.
+        scheduleTick();
+    }
+
+    fn on_datachannel_close(&mut self, channel_id: DatachannelId) {
+        console::log_1(&format!("data channel {channel_id} closed").into());
+
+        let Some(task) = self.task.as_mut() else { return; };
+
+        if channel_id == self.handshake_channel {
+            task.reset_substream(&channel_id);
+        }
+    }
+
+    fn on_datachannel_error(&mut self, channel_id: DatachannelId, msg: js_sys::JsString) {
+        console::log_1(&format!("data channel {channel_id} error: {msg}").into());
+
+        let Some(task) = self.task.as_mut() else { return; };
+
+        if channel_id == self.handshake_channel {
+            task.reset_substream(&channel_id);
+        }
+    }
+
+    fn on_message(&mut self, channel_id: DatachannelId, data: &[u8]) {
+        let rw = &mut self.perf_rw;
+        rw.now = Instant::now();
+        rw.wake_up_after = None;
+        rw.incoming_buffer.extend_from_slice(data);
+
+        match self.perf_framing.read_write(rw) {
+            Ok(mut framing) => {
+                let Some(stream) = self.perf_stream.take() else { return; };
+                self.perf_stream = stream.read_write(&mut framing);
+            }
+            Err(err) => {
+                if !matches!(err, Error::RemoteResetDesired) {
+                    console::log_1(&format!(
+                        "ClientInner::on_message(channel_id={channel_id}): framing error: {err:?}"
+                    ).into());
+                }
+                return;
+            }
+        } // on drop, `framing` adds the protobuf frame to `self.perf_rw.write_buffers`
+
+        match send(channel_id, rw.write_buffers.as_mut()) {
+            Ok(sent) => {
+                rw.write_bytes_queued = rw.write_bytes_queued.saturating_sub(sent);
+                rw.write_bytes_queueable = Some(rw.write_bytes_queueable.unwrap_or(0) + sent);
+            },
+            Err(SendError::SendQueueFull(sent)) => {
+                // FIXME: DRY
+                rw.write_bytes_queued = rw.write_bytes_queued.saturating_sub(sent);
+                rw.write_bytes_queueable = Some(rw.write_bytes_queueable.unwrap_or(0) + sent);
+
+                console::log_1(&format!(
+                    "ClientInner::on_message(channel_id={channel_id}): send queue is full"
+                ).into());
+            },
+            Err(SendError::Unknown(msg)) => {
+                console::log_1(&format!(
+                    "ClientInner::on_message(channel_id={channel_id}): unknown send error: {msg}"
+                ).into());
+            }
+        }
+
+        let Some(stream) = self.perf_stream.take() else { return; };
+        match (stream.upload_duration, stream.download_duration) {
+            (Some(upload_duration), Some(download_duration)) => {
+                let ud = upload_duration.as_secs_f64();
+                let dd = download_duration.as_secs_f64();
+
+                if let Err(e) = sendResults(ud, dd) {
+                    console::log_1(
+                        &format!("ClientInner::on_message(): sendResults() failed: {:?}", e).into()
+                    );
+                }
+            }
+            _ => {}
+        }
+        self.perf_stream = Some(stream);
+    }
+
+    fn on_time_elapsed(&mut self) {
+        let Some(channel_id) = self.perf_channel else {
+            console::log_1(&"ClientInner::on_time_elapsed(): no perf_channel, bailing".into());
+            return;
+        };
+        let rw = &mut self.perf_rw;
+        let mut total_sent = 0;
+
+        while rw.wake_up_after.map_or(false, |wua| rw.now >= wua) {
+            /* arbitrarily chosen 5 MB */
+            if total_sent >= 5242880 {
+                console::log_1(&"ClientInner::on_time_elapsed(): sent 5 MB, waiting for send queue to drain".into());
+                return;
+            }
+
+            rw.now = Instant::now();
+            rw.wake_up_after = None;
+
+            match self.perf_framing.read_write(rw) {
+                Ok(mut framing) => {
+                    let Some(stream) = self.perf_stream.take() else {
+                        console::log_1(&"ClientInner::on_time_elapsed(): no perf_stream, guess we're done here".into());
+                        return;
+                    };
+
+                    self.perf_stream = stream.read_write(&mut framing);
+
+                    if self.perf_stream.is_none() {
+                        self.perf_channel = None;
+                    }
+                }
+                Err(err) => {
+                    if !matches!(err, Error::RemoteResetDesired) {
+                        console::log_1(&format!(
+                            "ClientInner::on_time_elapsed(): framing error: {err:?}"
+                        ).into());
+                    }
+                    return;
+                }
+            } // on drop, `framing` adds the protobuf frame to `rw.write_buffers`
+
+            match send(channel_id, rw.write_buffers.as_mut()) {
+                Ok(sent) => {
+                    rw.write_bytes_queued = rw.write_bytes_queued.saturating_sub(sent);
+                    rw.write_bytes_queueable = Some(rw.write_bytes_queueable.unwrap_or(0) + sent);
+                    total_sent += sent;
+                },
+                Err(SendError::SendQueueFull(sent)) => {
+                    // FIXME: DRY
+                    rw.write_bytes_queued = rw.write_bytes_queued.saturating_sub(sent);
+                    rw.write_bytes_queueable = Some(rw.write_bytes_queueable.unwrap_or(0) + sent);
+
+                    console::log_1(&
+                        "ClientInner::on_time_elapsed(): send queue full, pausing sending"
+                    .into());
+                    return;
+                },
+                Err(SendError::Unknown(msg)) => {
+                    console::log_1(&format!(
+                        "ClientInner::on_time_elapsed(): unknown send error: {msg}"
+                    ).into());
+                    return;
+                }
+            }
+        }
+        if self.perf_stream.is_some() {
+            scheduleTick();
+        }
+    }
+
+    fn drive_handshake(&mut self, channel_id: DatachannelId, data: &[u8]) {
+        let Some(task) = self.task.as_mut() else { return; };
+        let rw = &mut self.handshake_rw;
+        rw.incoming_buffer.extend_from_slice(data);
+        rw.now = Instant::now();
+
+        if matches!(
+            task.substream_read_write(&channel_id, rw),
+            collection::SubstreamFate::Reset,
+        ) {
+            self.handshake_done = true;
+
+            match createDatachannel() {
+                Ok(n) => {
+                    self.perf_channel = Some(n.as_f64().unwrap() as DatachannelId);
+                }
+                Err(err) => {
+                    console::log_1(&format!(
+                        "ClientInner::drive_handshake(): createDatachannel() failed: {err:?}"
+                    ).into());
+                }
+            }
+        }
+
+        if let Err(SendError::Unknown(msg)) = send(channel_id, rw.write_buffers.as_mut()) {
+            console::log_1(&format!(
+                "ClientInner::drive_handshake(): unknown send error: {msg}"
+            ).into());
+        }
+    }
+}
+
+enum SendError {
+    SendQueueFull(usize),
+    Unknown(String),
+}
+
+fn send(channel_id: DatachannelId, write_buffers: &mut Vec<Vec<u8>>) -> Result<usize, SendError> {
+    let mut err: Option<SendError> = None;
+    let mut flattened = Vec::new();
+
+    write_buffers
+        .drain(..)
+        .filter(|chunk| !chunk.is_empty())
+        .for_each(|chunk| {
+            flattened.extend_from_slice(&chunk);
+        });
+
+    if flattened.is_empty() {
+        return Ok(0);
+    }
+
+    if let Err(e) = sendTo(channel_id, &flattened) {
+        let msg = format!("{e:?}");
+
+        err = if msg.contains("send queue is full") {
+            Some(SendError::SendQueueFull(0))
+        } else {
+            Some(SendError::Unknown(msg))
+        }
+    }
+
+    match err {
+        Some(err) => Err(err),
+        None => Ok(flattened.len()),
+    }
+}
+
+fn empty_read_write() -> ReadWrite<Instant> {
+    ReadWrite {
+        now: Instant::now(),
+        incoming_buffer: Vec::new(),
+        expected_incoming_bytes: Some(0),
+        read_bytes: 0,
+        write_buffers: Vec::new(),
+        write_bytes_queued: 0,
+        write_bytes_queueable: Some(128 * 1024),
+        wake_up_after: None,
+    }
+}
+
+fn build_noise_key(ed25519_private: &[u8; 32], noise_static_private: &[u8; 32]) -> noise::NoiseKey {
+    noise::NoiseKey::new(ed25519_private, noise_static_private)
+}
+
+fn parse_certhash_from_multiaddr(addr: &str) -> Result<Vec<u8>, String> {
+    // Find "/certhash/<mbase>" and decode the multibase base64url (no padding),
+    // then verify multihash header 0x12 0x20 and extract the 32-byte digest.
+    let key = "/certhash/";
+    let start = addr.find(key).ok_or("multiaddr missing /certhash/")? + key.len();
+    let end = addr[start..]
+        .find('/')
+        .map(|i| start + i)
+        .unwrap_or(addr.len());
+    let mbase = &addr[start..end];
+    if !mbase.starts_with('u') {
+        return Err("certhash must be base64url multibase (prefix 'u')".into());
+    }
+
+    let b64 = &mbase[1..];
+
+    use base64::Engine as _;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    let decoded = URL_SAFE_NO_PAD
+        .decode(b64)
+        .map_err(|e| format!("base64url decode: {e}"))?;
+    if decoded.len() != 34 || decoded[0] != 0x12 || decoded[1] != 0x20 {
+        return Err("certhash must be multihash sha2-256/32".into());
+    }
+    Ok(decoded)
+}

--- a/smoldot-perf/src/lib.rs
+++ b/smoldot-perf/src/lib.rs
@@ -1,20 +1,20 @@
 mod perf;
 
 use rand::{RngCore, SeedableRng, rngs::StdRng};
-use std::cell::RefCell;
-use std::fmt::{Display, Formatter};
-use std::rc::Rc;
-use std::time::Duration;
 use smoldot::libp2p::{
     collection,
     connection::{noise, webrtc_framing},
     read_write::ReadWrite,
 };
+use std::cell::RefCell;
+use std::fmt::{Display, Formatter};
+use std::rc::Rc;
+use std::time::Duration;
 
 use smoldot::libp2p::collection::ConnectionId;
+use smoldot::libp2p::connection::webrtc_framing::Error;
 use wasm_bindgen::prelude::*;
 use web_sys::console;
-use smoldot::libp2p::connection::webrtc_framing::Error;
 
 #[wasm_bindgen]
 extern "C" {
@@ -26,10 +26,7 @@ extern "C" {
     fn setGlue(glue: js_sys::Object);
 
     #[wasm_bindgen(catch)]
-    async fn dialWebRtcDirect(
-        address: String,
-        certificate: JsValue,
-    ) -> Result<JsValue, JsValue>;
+    async fn dialWebRtcDirect(address: String, certificate: JsValue) -> Result<JsValue, JsValue>;
 
     #[wasm_bindgen(catch)]
     fn sendTo(channel_id: u64, data: &[u8]) -> Result<(), JsValue>;
@@ -73,7 +70,7 @@ struct Instant(u64);
 
 impl Instant {
     fn now() -> Self {
-        // performance.now() returns fractional milliseconds. 
+        // performance.now() returns fractional milliseconds.
         // Multiplying by 1000 gives us microsecond precision.
         Self((now().as_f64().unwrap() * 1000.0) as u64)
     }
@@ -188,7 +185,7 @@ impl Client {
                 &JsValue::from_str("onDatachannelOpen"),
                 func.as_ref().unchecked_ref(),
             )
-                .unwrap();
+            .unwrap();
             func.forget();
         }
 
@@ -207,7 +204,7 @@ impl Client {
                 &JsValue::from_str("onDatachannelReady"),
                 func.as_ref().unchecked_ref(),
             )
-                .unwrap();
+            .unwrap();
             func.forget();
         }
 
@@ -226,7 +223,7 @@ impl Client {
                 &JsValue::from_str("onDatachannelClose"),
                 func.as_ref().unchecked_ref(),
             )
-                .unwrap();
+            .unwrap();
             func.forget();
         }
 
@@ -246,7 +243,7 @@ impl Client {
                 &JsValue::from_str("onDatachannelError"),
                 func.as_ref().unchecked_ref(),
             )
-                .unwrap();
+            .unwrap();
             func.forget();
         }
 
@@ -265,9 +262,10 @@ impl Client {
                     } else if this.perf_channel.is_some_and(|c| c == channel_id) {
                         this.on_message(channel_id, &data);
                     } else if !this.handshake_done {
-                        console::log_1(&format!(
-                            "got message on unknown channel {channel_id}. ignoring"
-                        ).into());
+                        console::log_1(
+                            &format!("got message on unknown channel {channel_id}. ignoring")
+                                .into(),
+                        );
                     }
                 },
             );
@@ -276,7 +274,7 @@ impl Client {
                 &JsValue::from_str("onMessage"),
                 func.as_ref().unchecked_ref(),
             )
-                .unwrap();
+            .unwrap();
             func.forget();
         }
 
@@ -284,16 +282,15 @@ impl Client {
         {
             let inner_rc = Rc::clone(&self.inner);
 
-            let func =
-                Closure::<dyn FnMut()>::new(move || {
-                    inner_rc.borrow_mut().on_time_elapsed();
-                });
+            let func = Closure::<dyn FnMut()>::new(move || {
+                inner_rc.borrow_mut().on_time_elapsed();
+            });
             js_sys::Reflect::set(
                 glue.as_ref(),
                 &JsValue::from_str("onTimeElapsed"),
                 func.as_ref().unchecked_ref(),
             )
-                .unwrap();
+            .unwrap();
             func.forget();
         }
 
@@ -362,7 +359,9 @@ impl ClientInner {
     fn on_datachannel_close(&mut self, channel_id: DatachannelId) {
         console::log_1(&format!("data channel {channel_id} closed").into());
 
-        let Some(task) = self.task.as_mut() else { return; };
+        let Some(task) = self.task.as_mut() else {
+            return;
+        };
 
         if channel_id == self.handshake_channel {
             task.reset_substream(&channel_id);
@@ -372,7 +371,9 @@ impl ClientInner {
     fn on_datachannel_error(&mut self, channel_id: DatachannelId, msg: js_sys::JsString) {
         console::log_1(&format!("data channel {channel_id} error: {msg}").into());
 
-        let Some(task) = self.task.as_mut() else { return; };
+        let Some(task) = self.task.as_mut() else {
+            return;
+        };
 
         if channel_id == self.handshake_channel {
             task.reset_substream(&channel_id);
@@ -387,7 +388,9 @@ impl ClientInner {
 
         match self.perf_framing.read_write(rw) {
             Ok(mut framing) => {
-                let Some(stream) = self.perf_stream.take() else { return; };
+                let Some(stream) = self.perf_stream.take() else {
+                    return;
+                };
                 self.perf_stream = stream.read_write(&mut framing);
             }
             Err(err) => {
@@ -404,16 +407,19 @@ impl ClientInner {
             Ok(sent) => {
                 rw.write_bytes_queued = rw.write_bytes_queued.saturating_sub(sent);
                 rw.write_bytes_queueable = Some(rw.write_bytes_queueable.unwrap_or(0) + sent);
-            },
+            }
             Err(SendError::SendQueueFull(sent)) => {
                 // FIXME: DRY
                 rw.write_bytes_queued = rw.write_bytes_queued.saturating_sub(sent);
                 rw.write_bytes_queueable = Some(rw.write_bytes_queueable.unwrap_or(0) + sent);
 
-                console::log_1(&format!(
-                    "ClientInner::on_message(channel_id={channel_id}): send queue is full"
-                ).into());
-            },
+                console::log_1(
+                    &format!(
+                        "ClientInner::on_message(channel_id={channel_id}): send queue is full"
+                    )
+                    .into(),
+                );
+            }
             Err(SendError::Unknown(msg)) => {
                 console::log_1(&format!(
                     "ClientInner::on_message(channel_id={channel_id}): unknown send error: {msg}"
@@ -421,7 +427,9 @@ impl ClientInner {
             }
         }
 
-        let Some(stream) = self.perf_stream.take() else { return; };
+        let Some(stream) = self.perf_stream.take() else {
+            return;
+        };
         match (stream.upload_duration, stream.download_duration) {
             (Some(upload_duration), Some(download_duration)) => {
                 let ud = upload_duration.as_secs_f64();
@@ -429,7 +437,7 @@ impl ClientInner {
 
                 if let Err(e) = sendResults(ud, dd) {
                     console::log_1(
-                        &format!("ClientInner::on_message(): sendResults() failed: {:?}", e).into()
+                        &format!("ClientInner::on_message(): sendResults() failed: {:?}", e).into(),
                     );
                 }
             }
@@ -449,7 +457,10 @@ impl ClientInner {
         while rw.wake_up_after.map_or(false, |wua| rw.now >= wua) {
             /* arbitrarily chosen 5 MB */
             if total_sent >= 5242880 {
-                console::log_1(&"ClientInner::on_time_elapsed(): sent 5 MB, waiting for send queue to drain".into());
+                console::log_1(
+                    &"ClientInner::on_time_elapsed(): sent 5 MB, waiting for send queue to drain"
+                        .into(),
+                );
                 return;
             }
 
@@ -471,9 +482,10 @@ impl ClientInner {
                 }
                 Err(err) => {
                     if !matches!(err, Error::RemoteResetDesired) {
-                        console::log_1(&format!(
-                            "ClientInner::on_time_elapsed(): framing error: {err:?}"
-                        ).into());
+                        console::log_1(
+                            &format!("ClientInner::on_time_elapsed(): framing error: {err:?}")
+                                .into(),
+                        );
                     }
                     return;
                 }
@@ -484,21 +496,22 @@ impl ClientInner {
                     rw.write_bytes_queued = rw.write_bytes_queued.saturating_sub(sent);
                     rw.write_bytes_queueable = Some(rw.write_bytes_queueable.unwrap_or(0) + sent);
                     total_sent += sent;
-                },
+                }
                 Err(SendError::SendQueueFull(sent)) => {
                     // FIXME: DRY
                     rw.write_bytes_queued = rw.write_bytes_queued.saturating_sub(sent);
                     rw.write_bytes_queueable = Some(rw.write_bytes_queueable.unwrap_or(0) + sent);
 
-                    console::log_1(&
-                        "ClientInner::on_time_elapsed(): send queue full, pausing sending"
-                    .into());
+                    console::log_1(
+                        &"ClientInner::on_time_elapsed(): send queue full, pausing sending".into(),
+                    );
                     return;
-                },
+                }
                 Err(SendError::Unknown(msg)) => {
-                    console::log_1(&format!(
-                        "ClientInner::on_time_elapsed(): unknown send error: {msg}"
-                    ).into());
+                    console::log_1(
+                        &format!("ClientInner::on_time_elapsed(): unknown send error: {msg}")
+                            .into(),
+                    );
                     return;
                 }
             }
@@ -509,7 +522,9 @@ impl ClientInner {
     }
 
     fn drive_handshake(&mut self, channel_id: DatachannelId, data: &[u8]) {
-        let Some(task) = self.task.as_mut() else { return; };
+        let Some(task) = self.task.as_mut() else {
+            return;
+        };
         let rw = &mut self.handshake_rw;
         rw.incoming_buffer.extend_from_slice(data);
         rw.now = Instant::now();
@@ -525,17 +540,20 @@ impl ClientInner {
                     self.perf_channel = Some(n.as_f64().unwrap() as DatachannelId);
                 }
                 Err(err) => {
-                    console::log_1(&format!(
-                        "ClientInner::drive_handshake(): createDatachannel() failed: {err:?}"
-                    ).into());
+                    console::log_1(
+                        &format!(
+                            "ClientInner::drive_handshake(): createDatachannel() failed: {err:?}"
+                        )
+                        .into(),
+                    );
                 }
             }
         }
 
         if let Err(SendError::Unknown(msg)) = send(channel_id, rw.write_buffers.as_mut()) {
-            console::log_1(&format!(
-                "ClientInner::drive_handshake(): unknown send error: {msg}"
-            ).into());
+            console::log_1(
+                &format!("ClientInner::drive_handshake(): unknown send error: {msg}").into(),
+            );
         }
     }
 }

--- a/smoldot-perf/src/perf.rs
+++ b/smoldot-perf/src/perf.rs
@@ -1,7 +1,7 @@
-use smoldot::libp2p::connection::multistream_select;
-use smoldot::libp2p::read_write::ReadWrite;
 use crate::Instant;
 use crate::perf::PerfStreamInner::Negotiating;
+use smoldot::libp2p::connection::multistream_select;
+use smoldot::libp2p::read_write::ReadWrite;
 use web_sys::console;
 
 pub const PROTOCOL_NAME: &str = "/litep2p-perf/1.0.0";
@@ -12,7 +12,7 @@ pub(crate) struct PerfStream {
 
     upload_bytes: u64,
     download_bytes: u64,
-    inner: PerfStreamInner
+    inner: PerfStreamInner,
 }
 
 impl PerfStream {
@@ -26,10 +26,7 @@ impl PerfStream {
         }
     }
 
-    pub fn read_write(
-        self,
-        read_write: &mut ReadWrite<Instant>,
-    ) -> Option<Self> {
+    pub fn read_write(self, read_write: &mut ReadWrite<Instant>) -> Option<Self> {
         let upload_bytes = self.upload_bytes;
         let download_bytes = self.download_bytes;
         let mut upload_duration = self.upload_duration;
@@ -41,7 +38,7 @@ impl PerfStream {
                     upload_duration = upload.into();
                     download_duration = download.into();
                 }
-                _ => {},
+                _ => {}
             }
 
             PerfStream {
@@ -54,42 +51,45 @@ impl PerfStream {
         })
     }
 
-    fn read_write2(
-        self,
-        read_write: &mut ReadWrite<Instant>,
-    ) -> Option<PerfStreamInner> {
+    fn read_write2(self, read_write: &mut ReadWrite<Instant>) -> Option<PerfStreamInner> {
         match self.inner {
             Negotiating(nego) => {
                 console::log_1(&"PerfStream::read_write2(): negotiating...".into());
 
                 match nego.read_write(read_write) {
-                    Ok(multistream_select::Negotiation::InProgress(nego)) =>
-                        Some(Negotiating(nego)),
+                    Ok(multistream_select::Negotiation::InProgress(nego)) => {
+                        Some(Negotiating(nego))
+                    }
                     Ok(multistream_select::Negotiation::Success) => {
                         console::log_1(&"PerfStream::read_write2(): done negotiating!".into());
                         read_write.wake_up_asap();
                         Some(PerfStreamInner::NumberOfBytesUpload)
-                    },
+                    }
                     Ok(multistream_select::Negotiation::NotAvailable) => None, // log?
                     Err(err) => {
                         console::log_1(&format!("kaput: {:?}", err).into());
                         None
-                    },
-                    _ => unreachable!("probably...")
+                    }
+                    _ => unreachable!("probably..."),
                 }
             }
             PerfStreamInner::NumberOfBytesUpload => {
-                console::log_1(&"PerfStream::read_write2(): sending number of bytes, upload".into());
+                console::log_1(
+                    &"PerfStream::read_write2(): sending number of bytes, upload".into(),
+                );
                 read_write.write_out(Vec::from(self.upload_bytes.to_be_bytes()));
                 read_write.wake_up_asap();
                 Some(PerfStreamInner::BytesUpload(self.upload_bytes, None))
-            },
+            }
             PerfStreamInner::BytesUpload(expected_bytes, mut started_at) => {
                 if expected_bytes == self.upload_bytes {
-                    console::log_1(&format!(
-                        "PerfStream::read_write2(): starting upload of {} bytes",
-                        self.upload_bytes,
-                    ).into());
+                    console::log_1(
+                        &format!(
+                            "PerfStream::read_write2(): starting upload of {} bytes",
+                            self.upload_bytes,
+                        )
+                        .into(),
+                    );
 
                     started_at = Some(read_write.now);
                 }
@@ -97,11 +97,13 @@ impl PerfStream {
                 let chunk_size: usize = match read_write.write_bytes_queueable {
                     Some(wbq) => {
                         if wbq == 0 {
-                            console::log_1(&"PerfStream::read_write2(): zero bytes queueable".into());
+                            console::log_1(
+                                &"PerfStream::read_write2(): zero bytes queueable".into(),
+                            );
                             return Some(PerfStreamInner::BytesUpload(expected_bytes, started_at));
                         }
                         std::cmp::min(wbq, 1024)
-                    },
+                    }
                     None => {
                         console::log_1(&"PerfStream::read_write2(): no bytes queueable".into());
                         return None;
@@ -119,9 +121,11 @@ impl PerfStream {
                     let upload_duration = read_write.now - started_at.unwrap();
                     Some(PerfStreamInner::NumberOfBytesDownload(upload_duration))
                 }
-            },
+            }
             PerfStreamInner::NumberOfBytesDownload(upload_duration) => {
-                console::log_1(&"PerfStream::read_write2(): sending number of bytes, download".into());
+                console::log_1(
+                    &"PerfStream::read_write2(): sending number of bytes, download".into(),
+                );
                 read_write.write_out(Vec::from(self.download_bytes.to_be_bytes()));
 
                 // FIXME: Including this breaks receiving the download bytes.
@@ -130,22 +134,34 @@ impl PerfStream {
                 // This should cause WebRtcFraming to include the FIN flag in the outgoing message.
                 // read_write.write_bytes_queueable = None;
 
-                Some(PerfStreamInner::BytesDownload(self.download_bytes, upload_duration, None))
-            },
+                Some(PerfStreamInner::BytesDownload(
+                    self.download_bytes,
+                    upload_duration,
+                    None,
+                ))
+            }
             PerfStreamInner::BytesDownload(expected_bytes, upload_duration, mut started_at) => {
                 if expected_bytes == self.download_bytes {
-                    console::log_1(&format!(
-                        "PerfStream::read_write2(): starting download of {} bytes",
-                        self.download_bytes,
-                    ).into());
+                    console::log_1(
+                        &format!(
+                            "PerfStream::read_write2(): starting download of {} bytes",
+                            self.download_bytes,
+                        )
+                        .into(),
+                    );
 
                     started_at = Some(read_write.now);
                 }
 
-                let remaining_bytes = expected_bytes.saturating_sub(read_write.incoming_buffer.len() as u64);
+                let remaining_bytes =
+                    expected_bytes.saturating_sub(read_write.incoming_buffer.len() as u64);
                 if remaining_bytes > 0 {
                     read_write.discard_all_incoming();
-                    Some(PerfStreamInner::BytesDownload(remaining_bytes, upload_duration, started_at))
+                    Some(PerfStreamInner::BytesDownload(
+                        remaining_bytes,
+                        upload_duration,
+                        started_at,
+                    ))
                 } else {
                     let download_duration = read_write.now - started_at.unwrap();
 
@@ -157,7 +173,7 @@ impl PerfStream {
 
                     Some(PerfStreamInner::Done(upload_duration, download_duration))
                 }
-            },
+            }
             PerfStreamInner::Done(_, _) => None,
         }
     }
@@ -182,8 +198,10 @@ enum PerfStreamInner {
 
 impl PerfStreamInner {
     fn new() -> Self {
-        Negotiating(multistream_select::InProgress::new(multistream_select::Config::Dialer {
-            requested_protocol: PROTOCOL_NAME.to_string(),
-        }))
+        Negotiating(multistream_select::InProgress::new(
+            multistream_select::Config::Dialer {
+                requested_protocol: PROTOCOL_NAME.to_string(),
+            },
+        ))
     }
 }

--- a/smoldot-perf/src/perf.rs
+++ b/smoldot-perf/src/perf.rs
@@ -1,0 +1,189 @@
+use smoldot::libp2p::connection::multistream_select;
+use smoldot::libp2p::read_write::ReadWrite;
+use crate::Instant;
+use crate::perf::PerfStreamInner::Negotiating;
+use web_sys::console;
+
+pub const PROTOCOL_NAME: &str = "/litep2p-perf/1.0.0";
+
+pub(crate) struct PerfStream {
+    pub upload_duration: Option<core::time::Duration>,
+    pub download_duration: Option<core::time::Duration>,
+
+    upload_bytes: u64,
+    download_bytes: u64,
+    inner: PerfStreamInner
+}
+
+impl PerfStream {
+    pub fn new(upload_bytes: u64, download_bytes: u64) -> Self {
+        Self {
+            upload_duration: None,
+            download_duration: None,
+            upload_bytes,
+            download_bytes,
+            inner: PerfStreamInner::new(),
+        }
+    }
+
+    pub fn read_write(
+        self,
+        read_write: &mut ReadWrite<Instant>,
+    ) -> Option<Self> {
+        let upload_bytes = self.upload_bytes;
+        let download_bytes = self.download_bytes;
+        let mut upload_duration = self.upload_duration;
+        let mut download_duration = self.download_duration;
+
+        self.read_write2(read_write).map(|inner| {
+            match inner {
+                PerfStreamInner::Done(upload, download) => {
+                    upload_duration = upload.into();
+                    download_duration = download.into();
+                }
+                _ => {},
+            }
+
+            PerfStream {
+                upload_duration,
+                download_duration,
+                upload_bytes,
+                download_bytes,
+                inner,
+            }
+        })
+    }
+
+    fn read_write2(
+        self,
+        read_write: &mut ReadWrite<Instant>,
+    ) -> Option<PerfStreamInner> {
+        match self.inner {
+            Negotiating(nego) => {
+                console::log_1(&"PerfStream::read_write2(): negotiating...".into());
+
+                match nego.read_write(read_write) {
+                    Ok(multistream_select::Negotiation::InProgress(nego)) =>
+                        Some(Negotiating(nego)),
+                    Ok(multistream_select::Negotiation::Success) => {
+                        console::log_1(&"PerfStream::read_write2(): done negotiating!".into());
+                        read_write.wake_up_asap();
+                        Some(PerfStreamInner::NumberOfBytesUpload)
+                    },
+                    Ok(multistream_select::Negotiation::NotAvailable) => None, // log?
+                    Err(err) => {
+                        console::log_1(&format!("kaput: {:?}", err).into());
+                        None
+                    },
+                    _ => unreachable!("probably...")
+                }
+            }
+            PerfStreamInner::NumberOfBytesUpload => {
+                console::log_1(&"PerfStream::read_write2(): sending number of bytes, upload".into());
+                read_write.write_out(Vec::from(self.upload_bytes.to_be_bytes()));
+                read_write.wake_up_asap();
+                Some(PerfStreamInner::BytesUpload(self.upload_bytes, None))
+            },
+            PerfStreamInner::BytesUpload(expected_bytes, mut started_at) => {
+                if expected_bytes == self.upload_bytes {
+                    console::log_1(&format!(
+                        "PerfStream::read_write2(): starting upload of {} bytes",
+                        self.upload_bytes,
+                    ).into());
+
+                    started_at = Some(read_write.now);
+                }
+
+                let chunk_size: usize = match read_write.write_bytes_queueable {
+                    Some(wbq) => {
+                        if wbq == 0 {
+                            console::log_1(&"PerfStream::read_write2(): zero bytes queueable".into());
+                            return Some(PerfStreamInner::BytesUpload(expected_bytes, started_at));
+                        }
+                        std::cmp::min(wbq, 1024)
+                    },
+                    None => {
+                        console::log_1(&"PerfStream::read_write2(): no bytes queueable".into());
+                        return None;
+                    }
+                };
+
+                read_write.write_out(vec![0u8; chunk_size]);
+                read_write.wake_up_asap();
+
+                let remaining_bytes = expected_bytes.saturating_sub(chunk_size as u64);
+                if remaining_bytes > 0 {
+                    Some(PerfStreamInner::BytesUpload(remaining_bytes, started_at))
+                } else {
+                    console::log_1(&"PerfStream::read_write2(): done uploading".into());
+                    let upload_duration = read_write.now - started_at.unwrap();
+                    Some(PerfStreamInner::NumberOfBytesDownload(upload_duration))
+                }
+            },
+            PerfStreamInner::NumberOfBytesDownload(upload_duration) => {
+                console::log_1(&"PerfStream::read_write2(): sending number of bytes, download".into());
+                read_write.write_out(Vec::from(self.download_bytes.to_be_bytes()));
+
+                // FIXME: Including this breaks receiving the download bytes.
+                // It should mean that this side won't send any more data, but the libp2p remote
+                // seems to interpret it as "substream closed".
+                // This should cause WebRtcFraming to include the FIN flag in the outgoing message.
+                // read_write.write_bytes_queueable = None;
+
+                Some(PerfStreamInner::BytesDownload(self.download_bytes, upload_duration, None))
+            },
+            PerfStreamInner::BytesDownload(expected_bytes, upload_duration, mut started_at) => {
+                if expected_bytes == self.download_bytes {
+                    console::log_1(&format!(
+                        "PerfStream::read_write2(): starting download of {} bytes",
+                        self.download_bytes,
+                    ).into());
+
+                    started_at = Some(read_write.now);
+                }
+
+                let remaining_bytes = expected_bytes.saturating_sub(read_write.incoming_buffer.len() as u64);
+                if remaining_bytes > 0 {
+                    read_write.discard_all_incoming();
+                    Some(PerfStreamInner::BytesDownload(remaining_bytes, upload_duration, started_at))
+                } else {
+                    let download_duration = read_write.now - started_at.unwrap();
+
+                    console::log_1(&format!(
+                        "PerfStream::read_write2(): done downloading. upload duration: {:?} download duration: {:?}",
+                        upload_duration,
+                        download_duration,
+                    ).into());
+
+                    Some(PerfStreamInner::Done(upload_duration, download_duration))
+                }
+            },
+            PerfStreamInner::Done(_, _) => None,
+        }
+    }
+}
+
+enum PerfStreamInner {
+    Negotiating(multistream_select::InProgress<String>),
+    NumberOfBytesUpload,
+
+    // expected bytes, instant when the upload started
+    BytesUpload(u64, Option<Instant>),
+
+    // upload duration
+    NumberOfBytesDownload(core::time::Duration),
+
+    // expected bytes, upload duration, instant when the download started
+    BytesDownload(u64, core::time::Duration, Option<Instant>),
+
+    // upload duration, download duration
+    Done(core::time::Duration, core::time::Duration),
+}
+
+impl PerfStreamInner {
+    fn new() -> Self {
+        Negotiating(multistream_select::InProgress::new(multistream_select::Config::Dialer {
+            requested_protocol: PROTOCOL_NAME.to_string(),
+        }))
+    }
+}


### PR DESCRIPTION
This PR adds a minimal WebRTC dialer based on the [smoldot](https://github.com/smol-dot/smoldot) codebase that implements the litep2p-perf protocol.

It is based off #2, so this PR should be reviewed and merged first.

In order to run this, the host machine needs to have Chrome installed. The [`headless_chrome`](https://crates.io/crates/headless_chrome) crate can download a Chrome binary if necessary. This could be enabled, but for now I've opted not to.

Other requirements apart from a Rust toolchain are an installed `wasm32-unknown-unknown` target as well as the `wasm-bindgen-cli` crate, which needs to be installed in the exact same version as is used in the `smoldot-perf` package. This is checked in the `smoldot-automation` executable.

I tried to run the dialer in Docker, but ran into networking issues I was unable to resolve.

One limitation I've noticed is that the `performance.now()` function available in the browser for measuring time passed lacks the necessary precision to measure the bandwidth for small amounts of data, like 1 kiB.

So far this PR encompasses only connecting from a dialer in Chrome to a litep2p-based listener. We could also add a libp2p-based listener and/or run the dialer in Firefox. But I'd suggest we add that in a follow-up PR.